### PR TITLE
add DOCBUILDER_ARGUMENTS env var for building document

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -17,6 +17,7 @@ env:
   TAG_NAME: ${{ github.ref_name }}
   REF_NAME: ${{ github.ref_name }}
   DEFAULT_REF: ${{ github.base_ref }}
+  DOCBUILDER_ARGUMENTS: --configfile "./maindoc_configs/maindoc_config_OSS.json"
 
 jobs:
   build-linux:

--- a/config/repositories/repositories.conf
+++ b/config/repositories/repositories.conf
@@ -9,6 +9,8 @@ python-genpackagedoc=
 python-extensions-collection=
 python-jsonpreprocessor=
 python-pytestlog2db=
+python-microservice-base=
+python-microservice-cleware-switch=
 
 robotframework=
 robotframework-extensions-collection=


### PR DESCRIPTION
Hi Thomas,

Github workflow is updated due to change from robotframework-document repo with **DOCBUILDER_ARGUMENTS** env var and new repos for microservice.

I triggered manually with my change, the builds are recovered now:
https://github.com/test-fullautomation/RobotFramework_AIO/actions/runs/4130982148

Thank you,
Ngoan