### PR TITLE
Introduction of fully automated continuous test

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -92,6 +92,9 @@ jobs:
     name: Test Windows package
     runs-on: windows-latest
     needs: build-windows
+    env:
+      RobotPythonPath: "C:/Program Files/RobotFramework/python39"
+      RobotTutorialPath: "C:/RobotTest/tutorial"
 
     steps:
     - name: Support long path in git
@@ -117,8 +120,7 @@ jobs:
       shell: cmd
       run: |
         set Robot
-        "C:\Program Files\RobotFramework\python39\python" test/aio-test-trigger/aio-test-trigger.py
-
+        "%RobotPythonPath%/python" test/aio-test-trigger/aio-test-trigger.py
 
   install-test-linux:
     name: Test Linux package
@@ -146,32 +148,45 @@ jobs:
       run: |
         . /opt/rfwaio/linux/set_robotenv.sh
         printenv | grep Robot
-        /opt/rfwaio/python39/install/bin/python3.9 test/aio-test-trigger/aio-test-trigger.py
+        $RobotPythonPath/python3.9 test/aio-test-trigger/aio-test-trigger.py
 
-  # release:
-  #   runs-on: ubuntu-latest
-  #   needs: [install-test-windows, install-test-linux]
+  release:
+    name: Release AIO
+    runs-on: ubuntu-latest
+    needs: [install-test-windows, install-test-linux]
+    # if: github.ref_type == 'tag'
 
-  #   steps:
-  #   - name: Download artifact from build workflow
-  #     uses: actions/download-artifact@v2
-  #     # with:
-  #     #   name: windows-package
-  #     #   path: windows
+    steps:
+    - name: Download artifact from build workflow
+      uses: actions/download-artifact@v2
 
-  #   - name: Unzip artifact
-  #     run: |
-  #       unzip artifact-from-build-workflow/artifact-from-build-workflow.zip -d artifact-from-build-workflow
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ env.TAG_NAME }}
+        release_name: Release v${{ env.TAG_NAME }}
+        draft: false
+        prerelease: false
 
-  #   - name: Create Release
-  #     uses: actions/create-release@v1
-  #     env:
-  #       GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
-  #     with:
-  #       tag_name: v${{ env.TAG_NAME }}
-  #       release_name: Release v${{ env.TAG_NAME }}
-  #       draft: false
-  #       prerelease: false
-  #       assets:
-  #       - name: artifact-from-build-workflow
-  #         path: artifact-from-build-workflow          path: Output/
+    - name: Upload Windows Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./*.exe
+        # asset_name: setup_RobotFramework_AIO_Win_${{ env.TAG_NAME }}.exe
+        asset_content_type: application/octet-stream
+
+    - name: Upload Linux Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./*.deb
+        # asset_name: setup_RobotFramework_AIO_Linux_${{ env.TAG_NAME }}.deb
+        asset_content_type: application/vnd.debian.binary-package

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -113,7 +113,7 @@ jobs:
       shell: cmd
       run: |
         set Robot
-        ${{ env.RobotPythonPath }}/python test/aio-test-trigger/aio-test-trigger.py
+        "C:\Program Files\RobotFramework\python39\python" test/aio-test-trigger/aio-test-trigger.py
 
 
   install-test-linux:

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -136,7 +136,7 @@ jobs:
     - name: Run tests on Linux
       run: |
         printenv | grep Robot
-        ${{ env.RobotPythonPath }}/python test/aio-test-trigger/aio-test-trigger.py
+        /opt/rfwaio/python39/install/bin/python3.9 test/aio-test-trigger/aio-test-trigger.py
 
   # release:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -121,11 +121,10 @@ jobs:
       run: choco install pandoc
 
     - name: Run tests on Windows
-      shell: bash
+      shell: cmd
       run: |
         set Robot
-        echo $(where pandoc)
-        echo "%RobotPythonPath%/python" test/aio-test-trigger/aio-test-trigger.py
+        "%RobotPythonPath%/python" test/aio-test-trigger/aio-test-trigger.py
 
   install-test-linux:
     name: Test Linux package
@@ -153,8 +152,8 @@ jobs:
       run: |
         . /opt/rfwaio/linux/set_robotenv.sh
         printenv | grep Robot
-        echo $(where pandoc)
-        echo $RobotPythonPath/python3.9 test/aio-test-trigger/aio-test-trigger.py
+        echo $(which pandoc)
+        $RobotPythonPath/python3.9 test/aio-test-trigger/aio-test-trigger.py
 
   release:
     name: Release AIO
@@ -170,7 +169,7 @@ jobs:
       id: create_release
       uses: actions/create-release@v1
       env:
-        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         # tag_name: v${{ env.TAG_NAME }}
         tag_name: rel/aio/1.1.1.1

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -159,11 +159,17 @@ jobs:
     name: Release AIO
     runs-on: ubuntu-latest
     needs: [install-test-windows, install-test-linux]
-    # if: github.ref_type == 'tag'
+    if: github.ref_type == 'tag'
 
     steps:
     - name: Download artifact from build workflow
       uses: actions/download-artifact@v2
+
+    - name: Get released file names
+      run: |
+        echo "EXE_FILE=$(ls windows-package/*.exe | head -1)" >> $GITHUB_ENV
+        echo "DEB_FILE=$(ls linux-package/*.deb | head -1)" >> $GITHUB_ENV
+        echo "RELEASE_VERSION=${TAG_NAME#rel/aio/}" >> $GITHUB_ENV
 
     - name: Create Release
       id: create_release
@@ -171,9 +177,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        # tag_name: v${{ env.TAG_NAME }}
-        tag_name: rel/aio/1.1.1.1
-        release_name: RobotFramework AIO version ${{ env.TAG_NAME }}
+        tag_name: v${{ env.TAG_NAME }}
+        release_name: RobotFramework AIO version ${{ env.RELEASE_VERSION }}
         draft: false
         prerelease: false
 
@@ -183,8 +188,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./*.exe
-        asset_name: setup_RobotFramework_AIO_Win_${{ env.TAG_NAME }}.exe
+        asset_path: ${{ env.EXE_FILE }}
+        asset_name: setup_RobotFramework_AIO_Win_${{ env.RELEASE_VERSION }}.exe
         asset_content_type: application/octet-stream
 
     - name: Upload Linux Release Asset
@@ -193,6 +198,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./*.deb
-        asset_name: setup_RobotFramework_AIO_Linux_${{ env.TAG_NAME }}.deb
+        asset_path: ${{ env.DEB_FILE }}
+        asset_name: setup_RobotFramework_AIO_Linux_${{ env.RELEASE_VERSION }}.deb
         asset_content_type: application/vnd.debian.binary-package

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -144,6 +144,7 @@ jobs:
 
     - name: Run tests on Linux
       run: |
+        . /opt/rfwaio/linux/set_robotenv.sh
         printenv | grep Robot
         /opt/rfwaio/python39/install/bin/python3.9 test/aio-test-trigger/aio-test-trigger.py
 

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -112,14 +112,19 @@ jobs:
       with:
         name: windows-package
 
-    - name: Install on Windows
+    - name: Install RobotFramework AIO on Windows
       shell: cmd
       run: ./scripts/install-windows.bat
 
-    - name: Run tests on Windows
+    - name: Install pandoc on Windows
       shell: cmd
+      run: choco install pandoc
+
+    - name: Run tests on Windows
+      shell: bash
       run: |
         set Robot
+        echo $(where pandoc)
         echo "%RobotPythonPath%/python" test/aio-test-trigger/aio-test-trigger.py
 
   install-test-linux:
@@ -148,6 +153,7 @@ jobs:
       run: |
         . /opt/rfwaio/linux/set_robotenv.sh
         printenv | grep Robot
+        echo $(where pandoc)
         echo $RobotPythonPath/python3.9 test/aio-test-trigger/aio-test-trigger.py
 
   release:

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -173,7 +173,7 @@ jobs:
       with:
         # tag_name: v${{ env.TAG_NAME }}
         tag_name: rel/aio/1.1.1.1
-        release_name: Release ${{ env.TAG_NAME }}
+        release_name: RobotFramework AIO version ${{ env.TAG_NAME }}
         draft: false
         prerelease: false
 
@@ -184,7 +184,7 @@ jobs:
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./*.exe
-        # asset_name: setup_RobotFramework_AIO_Win_${{ env.TAG_NAME }}.exe
+        asset_name: setup_RobotFramework_AIO_Win_${{ env.TAG_NAME }}.exe
         asset_content_type: application/octet-stream
 
     - name: Upload Linux Release Asset
@@ -194,5 +194,5 @@ jobs:
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./*.deb
-        # asset_name: setup_RobotFramework_AIO_Linux_${{ env.TAG_NAME }}.deb
+        asset_name: setup_RobotFramework_AIO_Linux_${{ env.TAG_NAME }}.deb
         asset_content_type: application/vnd.debian.binary-package

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -100,6 +100,10 @@ jobs:
     - name: Checkout source
       uses: actions/checkout@v2
 
+    - name: Clone repositories
+      shell: bash
+      run: ./cloneall
+
     - name: Download Windows installer package
       uses: actions/download-artifact@v2
       with:
@@ -124,6 +128,11 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v2
+
+    - name: Clone repositories
+      run: |
+        chmod +x ./cloneall
+        ./cloneall
 
     - name: Download Linux installer package
       uses: actions/download-artifact@v2

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -104,9 +104,7 @@ jobs:
 
     - name: Install on Windows
       shell: cmd
-      run: |
-        tar -xf windows-package.zip
-        ./scripts/install-windows.bat
+      run: ./scripts/install-windows.bat
 
     - name: Run tests on Windows
       shell: cmd
@@ -128,13 +126,10 @@ jobs:
         name: linux-package
 
     - name: Install on Linux
-      run: |
-        pwd
-        ls -alh
-        unzip -q ./linux-package.zip  && sudo apt-get install *.deb
+      run: sudo apt-get install ./*.deb
 
     - name: Run tests on Linux
-      run: python test/aio-test-trigger/aio-test-trigger.py
+      run: $RobotPythonPath/python test/aio-test-trigger/aio-test-trigger.py
 
   # release:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -20,39 +20,39 @@ env:
   DOCBUILDER_ARGUMENTS: --configfile "./maindoc_configs/maindoc_config_OSS.json"
 
 jobs:
-  # build-linux:
-  #   name: Build Linux package
-  #   runs-on: ubuntu-latest
+  build-linux:
+    name: Build Linux package
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout source
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
 
-  #     - name: Install dependencies
-  #       run: |
-  #         chmod +x ./requirements_linux.sh
-  #         ./requirements_linux.sh
+      - name: Install dependencies
+        run: |
+          chmod +x ./requirements_linux.sh
+          ./requirements_linux.sh
 
-  #     - name: Clone repositories
-  #       run: |
-  #         chmod +x ./cloneall
-  #         ./cloneall
+      - name: Clone repositories
+        run: |
+          chmod +x ./cloneall
+          ./cloneall
 
-  #     - name: Install
-  #       run: |
-  #         chmod +x ./install/install.sh
-  #         ./install/install.sh
+      - name: Install
+        run: |
+          chmod +x ./install/install.sh
+          ./install/install.sh
 
-  #     - name: Build
-  #       run: |
-  #         chmod +x ./build
-  #         ./build
+      - name: Build
+        run: |
+          chmod +x ./build
+          ./build
 
-  #     - name: Upload built package
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: linux-package
-  #         path: output_lx/*.deb
+      - name: Upload built package
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-package
+          path: output_lx/*.deb
 
   build-windows:
     name: Build Windows package
@@ -89,7 +89,7 @@ jobs:
           path: Output/
 
   install-test-windows:
-    name: Build Windows package
+    name: Test Windows package
     runs-on: windows-latest
     needs: build-windows
 
@@ -113,15 +113,25 @@ jobs:
       run: python test/aio-test-trigger/aio-test-trigger.py
 
 
-  # install-test-linux:
-  #   name: Build Linux package
-  #   runs-on: ubuntu-latest
-  #   needs: build-linux
+  install-test-linux:
+    name: Test Linux package
+    runs-on: ubuntu-latest
+    needs: build-linux
 
-  #   steps:
-  #   - name: Download Linux installer package
-  #   - name: Install on Linux
-  #   - name: Run tests on Linux
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v2
+
+    - name: Download Linux installer package
+      uses: actions/download-artifact@v2
+      with:
+        name: linux-package
+
+    - name: Install on Linux
+      run: unzip -q linux-package.zip && sudo apt-get install linux-package/*.deb
+
+    - name: Run tests on Linux
+      run: python test/aio-test-trigger/aio-test-trigger.py
 
   # release:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -20,39 +20,39 @@ env:
   DOCBUILDER_ARGUMENTS: --configfile "./maindoc_configs/maindoc_config_OSS.json"
 
 jobs:
-  build-linux:
-    name: Build Linux package
-    runs-on: ubuntu-latest
+  # build-linux:
+  #   name: Build Linux package
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout source
+  #       uses: actions/checkout@v2
 
-      - name: Install dependencies
-        run: |
-          chmod +x ./requirements_linux.sh
-          ./requirements_linux.sh
+  #     - name: Install dependencies
+  #       run: |
+  #         chmod +x ./requirements_linux.sh
+  #         ./requirements_linux.sh
 
-      - name: Clone repositories
-        run: |
-          chmod +x ./cloneall
-          ./cloneall
+  #     - name: Clone repositories
+  #       run: |
+  #         chmod +x ./cloneall
+  #         ./cloneall
 
-      - name: Install
-        run: |
-          chmod +x ./install/install.sh
-          ./install/install.sh
+  #     - name: Install
+  #       run: |
+  #         chmod +x ./install/install.sh
+  #         ./install/install.sh
 
-      - name: Build
-        run: |
-          chmod +x ./build
-          ./build
+  #     - name: Build
+  #       run: |
+  #         chmod +x ./build
+  #         ./build
 
-      - name: Upload built package
-        uses: actions/upload-artifact@v3
-        with:
-          name: linux-package
-          path: output_lx/*.deb
+  #     - name: Upload built package
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: linux-package
+  #         path: output_lx/*.deb
 
   build-windows:
     name: Build Windows package
@@ -87,3 +87,66 @@ jobs:
         with:
           name: windows-package
           path: Output/
+
+  install-test-windows:
+    name: Build Windows package
+    runs-on: windows-latest
+    needs: build-windows
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v2
+
+    - name: Download Windows installer package
+      uses: actions/download-artifact@v2
+      with:
+        name: windows-package
+
+    - name: Install on Windows
+      shell: cmd
+      run: |
+        tar -xf windows-package.zip
+        ./scripts/install-windows.bat
+
+    - name: Run tests on Windows
+      shell: cmd
+      run: python test/aio-test-trigger/aio-test-trigger.py
+
+
+  # install-test-linux:
+  #   name: Build Linux package
+  #   runs-on: ubuntu-latest
+  #   needs: build-linux
+
+  #   steps:
+  #   - name: Download Linux installer package
+  #   - name: Install on Linux
+  #   - name: Run tests on Linux
+
+  # release:
+  #   runs-on: ubuntu-latest
+  #   needs: [install-test-windows, install-test-linux]
+
+  #   steps:
+  #   - name: Download artifact from build workflow
+  #     uses: actions/download-artifact@v2
+  #     # with:
+  #     #   name: windows-package
+  #     #   path: windows
+
+  #   - name: Unzip artifact
+  #     run: |
+  #       unzip artifact-from-build-workflow/artifact-from-build-workflow.zip -d artifact-from-build-workflow
+
+  #   - name: Create Release
+  #     uses: actions/create-release@v1
+  #     env:
+  #       GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+  #     with:
+  #       tag_name: v${{ env.TAG_NAME }}
+  #       release_name: Release v${{ env.TAG_NAME }}
+  #       draft: false
+  #       prerelease: false
+  #       assets:
+  #       - name: artifact-from-build-workflow
+  #         path: artifact-from-build-workflow          path: Output/

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -128,7 +128,10 @@ jobs:
         name: linux-package
 
     - name: Install on Linux
-      run: unzip -q linux-package.zip && sudo apt-get install linux-package/*.deb
+      run: |
+        pwd
+        ls -alh
+        unzip -q ./linux-package.zip  && sudo apt-get install *.deb
 
     - name: Run tests on Linux
       run: python test/aio-test-trigger/aio-test-trigger.py

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -177,7 +177,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: v${{ env.TAG_NAME }}
+        tag_name: ${{ env.TAG_NAME }}
         release_name: RobotFramework AIO version ${{ env.RELEASE_VERSION }}
         draft: false
         prerelease: false

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -120,7 +120,7 @@ jobs:
       shell: cmd
       run: |
         set Robot
-        "%RobotPythonPath%/python" test/aio-test-trigger/aio-test-trigger.py
+        echo "%RobotPythonPath%/python" test/aio-test-trigger/aio-test-trigger.py
 
   install-test-linux:
     name: Test Linux package
@@ -148,7 +148,7 @@ jobs:
       run: |
         . /opt/rfwaio/linux/set_robotenv.sh
         printenv | grep Robot
-        $RobotPythonPath/python3.9 test/aio-test-trigger/aio-test-trigger.py
+        echo $RobotPythonPath/python3.9 test/aio-test-trigger/aio-test-trigger.py
 
   release:
     name: Release AIO
@@ -166,8 +166,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
       with:
-        tag_name: v${{ env.TAG_NAME }}
-        release_name: Release v${{ env.TAG_NAME }}
+        # tag_name: v${{ env.TAG_NAME }}
+        tag_name: rel/aio/1.1.1.1
+        release_name: Release ${{ env.TAG_NAME }}
         draft: false
         prerelease: false
 

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -94,6 +94,9 @@ jobs:
     needs: build-windows
 
     steps:
+    - name: Support long path in git
+      run: git config --system core.longpaths true
+
     - name: Checkout source
       uses: actions/checkout@v2
 
@@ -108,7 +111,9 @@ jobs:
 
     - name: Run tests on Windows
       shell: cmd
-      run: python test/aio-test-trigger/aio-test-trigger.py
+      run: |
+        set Robot
+        ${{ env.RobotPythonPath }}/python test/aio-test-trigger/aio-test-trigger.py
 
 
   install-test-linux:
@@ -129,7 +134,9 @@ jobs:
       run: sudo apt-get install ./*.deb
 
     - name: Run tests on Linux
-      run: $RobotPythonPath/python test/aio-test-trigger/aio-test-trigger.py
+      run: |
+        printenv | grep Robot
+        ${{ env.RobotPythonPath }}/python test/aio-test-trigger/aio-test-trigger.py
 
   # release:
   #   runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ output_lx/
 __pycache__/
 logfiles/
 ExecutionLogFile.log
+test/**/*.html
+test/**/*.xml
+test/**/*.log

--- a/config/build/dpkg_build/control
+++ b/config/build/dpkg_build/control
@@ -3,7 +3,7 @@ Version: 0.6.0.5
 Section: base
 Priority: optional
 Architecture: amd64
-Depends: libmariadb-dev-compat | libmariadb-dev | libmariadbclient18 | libmariadb3
+Depends: libmariadb-dev-compat | libmariadb-dev | libmariadbclient18 | libmariadb3, pandoc
 Maintainer: Thomas Pollerspöck (Thomas.Pollerspoeck@de.bosch.com)
 Description: RobotFramework AIO (All In One)
 

--- a/requirements_windows.sh
+++ b/requirements_windows.sh
@@ -24,11 +24,10 @@ texlive_packages=(
 "trimspaces"
 "listings"
 "pdfcol"
-"tikz*"
 )
 extra_packages=""
 for package in ${texlive_packages[@]}; do
   extra_packages+="$package,"
 done
 
-choco install texlive --version=2022.20221202 --params "'/extraPackages:${extra_packages::-1}'"
+choco install texlive --version=2022.20221202 --params "'/collections:pictures,latex /extraPackages:${extra_packages::-1}'"

--- a/requirements_windows.sh
+++ b/requirements_windows.sh
@@ -24,6 +24,7 @@ texlive_packages=(
 "trimspaces"
 "listings"
 "pdfcol"
+"tikz*"
 )
 extra_packages=""
 for package in ${texlive_packages[@]}; do

--- a/scripts/install-windows.bat
+++ b/scripts/install-windows.bat
@@ -1,0 +1,27 @@
+@echo off
+setlocal enabledelayedexpansion
+
+if "%~1"=="" (
+  set "directory=%cd%"
+) else (
+  set "directory=%~1"
+)
+
+echo The directory is set to: %directory%
+
+set "app="
+for /f "tokens=*" %%a in ('dir /b !directory!\*.exe') do (
+    if not defined app (
+        set "app=%%~na"
+        start /wait "" "!directory!\%%a" /SILENT /NORESTART /LOG=install-windows.log
+        if !errorlevel! equ 0 (
+            echo !app! installation successful.
+        ) else (
+            echo !app! installation failed.
+        )
+    )
+)
+
+if not defined app (
+    echo No executable file found in current directory.
+)

--- a/test/aio-test-trigger/config/testtrigger_config.json
+++ b/test/aio-test-trigger/config/testtrigger_config.json
@@ -80,13 +80,13 @@
                        "TESTTYPE"          : "PYTEST",
                        "TESTEXECUTOR"      : "executepytest.py",
                        "LOGFILE"           : "../../../../robotframework-robotlog2rqm/pytest/aiotestlogfiles/aiotestlogfile.xml"
-#                    },
-#                    {
-#                       "COMPONENTROOTPATH" : "../../tutorial-test",
-#                       "TESTFOLDER"        : "pytest",
-#                       "TESTTYPE"          : "PYTEST",
-#                       "TESTEXECUTOR"      : "executepytest.py",
-#                       "LOGFILE"           : "../../tutorial-test/pytest/aiotestlogfiles/aiotestlogfile.xml"
+                    },
+                    {
+                       "COMPONENTROOTPATH" : "../../tutorial-test",
+                       "TESTFOLDER"        : "pytest",
+                       "TESTTYPE"          : "PYTEST",
+                       "TESTEXECUTOR"      : "executepytest.py",
+                       "LOGFILE"           : "../../tutorial-test/pytest/aiotestlogfiles/aiotestlogfile.xml"
                     }
                   ],
 

--- a/test/aio-test-trigger/config/testtrigger_config.json
+++ b/test/aio-test-trigger/config/testtrigger_config.json
@@ -80,13 +80,13 @@
                        "TESTTYPE"          : "PYTEST",
                        "TESTEXECUTOR"      : "executepytest.py",
                        "LOGFILE"           : "../../../../robotframework-robotlog2rqm/pytest/aiotestlogfiles/aiotestlogfile.xml"
-                    },
-                    {
-                       "COMPONENTROOTPATH" : "../../tutorial-test",
-                       "TESTFOLDER"        : "pytest",
-                       "TESTTYPE"          : "PYTEST",
-                       "TESTEXECUTOR"      : "executepytest.py",
-                       "LOGFILE"           : "../../tutorial-test/pytest/aiotestlogfiles/aiotestlogfile.xml"
+#                    },
+#                    {
+#                       "COMPONENTROOTPATH" : "../../tutorial-test",
+#                       "TESTFOLDER"        : "pytest",
+#                       "TESTTYPE"          : "PYTEST",
+#                       "TESTEXECUTOR"      : "executepytest.py",
+#                       "LOGFILE"           : "../../tutorial-test/pytest/aiotestlogfiles/aiotestlogfile.xml"
                     }
                   ],
 
@@ -106,12 +106,10 @@
 
    "TESTTYPES" : {
                   "ROBOT"  : {
-                               "DATABASEEXECUTOR" : "%RobotPythonPath%/Lib/site-packages/RobotLog2DB/robotlog2db.py",
-                               "LOCALCOMMANDLINE" : ["-h"]
+                               "DATABASEEXECUTOR" : "../mocks/pytest2db-mock.py"
                              },
                   "PYTEST" : {
-                               "DATABASEEXECUTOR" : "%RobotPythonPath%/Lib/site-packages/PyTestLog2DB/pytestlog2db.py",
-                               "LOCALCOMMANDLINE" : ["-h"]
+                               "DATABASEEXECUTOR" : "../mocks/robot2db-mock.py"
                              }
                 }
 }

--- a/test/aio-test-trigger/config/testtrigger_config.json
+++ b/test/aio-test-trigger/config/testtrigger_config.json
@@ -106,12 +106,10 @@
 
    "TESTTYPES" : {
                   "ROBOT"  : {
-                               "DATABASEEXECUTOR" : "%RobotPythonPath%/Lib/site-packages/RobotLog2DB/robotlog2db.py",
-                               "LOCALCOMMANDLINE" : ["${server}", "${user}", "${password}", "${database}", "-UUID ${UUID}", "--variant ${variant}", "--versions ${versions}", "--config ${config}", "${append}", "${dryrun}"]
+                               "DATABASEEXECUTOR" : "../mocks/robot2db-mock.py"
                              },
                   "PYTEST" : {
-                               "DATABASEEXECUTOR" : "%RobotPythonPath%/Lib/site-packages/PyTestLog2DB/pytestlog2db.py",
-                               "LOCALCOMMANDLINE" : ["${server}", "${user}", "${password}", "${database}", "--UUID ${UUID}", "--config ${config}", "${append}", "${dryrun}"]
-                             }
+                               "DATABASEEXECUTOR" : "../mocks/pytest2db-mock.py"
+                  }
                 }
 }

--- a/test/aio-test-trigger/config/testtrigger_config.json
+++ b/test/aio-test-trigger/config/testtrigger_config.json
@@ -82,13 +82,6 @@
                        "LOGFILE"           : "../../../../robotframework-robotlog2rqm/pytest/aiotestlogfiles/aiotestlogfile.xml"
                     },
                     {
-                       "COMPONENTROOTPATH" : "../../../../robotframework-tmllog2robotlog",
-                       "TESTFOLDER"        : "pytest",
-                       "TESTTYPE"          : "PYTEST",
-                       "TESTEXECUTOR"      : "executepytest.py",
-                       "LOGFILE"           : "../../../../robotframework-tmllog2robotlog/pytest/aiotestlogfiles/aiotestlogfile.xml"
-                    },
-                    {
                        "COMPONENTROOTPATH" : "../../tutorial-test",
                        "TESTFOLDER"        : "pytest",
                        "TESTTYPE"          : "PYTEST",

--- a/test/aio-test-trigger/config/testtrigger_config.json
+++ b/test/aio-test-trigger/config/testtrigger_config.json
@@ -106,10 +106,14 @@
 
    "TESTTYPES" : {
                   "ROBOT"  : {
-                               "DATABASEEXECUTOR" : "../mocks/robot2db-mock.py"
+                               "DATABASEEXECUTOR" : "%RobotPythonPath%/Lib/site-packages/RobotLog2DB/robotlog2db.py",
+                              //  "LOCALCOMMANDLINE" : ["${server}", "${user}", "${password}", "${database}", "-UUID ${UUID}", "--variant ${variant}", "--versions ${versions}", "--config ${config}", "${append}", "${dryrun}"]
+                               "LOCALCOMMANDLINE" : ["-h"]
                              },
                   "PYTEST" : {
-                               "DATABASEEXECUTOR" : "../mocks/pytest2db-mock.py"
-                  }
+                               "DATABASEEXECUTOR" : "%RobotPythonPath%/Lib/site-packages/PyTestLog2DB/pytestlog2db.py",
+                              //  "LOCALCOMMANDLINE" : ["${server}", "${user}", "${password}", "${database}", "--UUID ${UUID}", "--config ${config}", "${append}", "${dryrun}"]
+                               "LOCALCOMMANDLINE" : ["-h"]
+                             }
                 }
 }

--- a/test/aio-test-trigger/config/testtrigger_config.json
+++ b/test/aio-test-trigger/config/testtrigger_config.json
@@ -107,12 +107,10 @@
    "TESTTYPES" : {
                   "ROBOT"  : {
                                "DATABASEEXECUTOR" : "%RobotPythonPath%/Lib/site-packages/RobotLog2DB/robotlog2db.py",
-                              //  "LOCALCOMMANDLINE" : ["${server}", "${user}", "${password}", "${database}", "-UUID ${UUID}", "--variant ${variant}", "--versions ${versions}", "--config ${config}", "${append}", "${dryrun}"]
                                "LOCALCOMMANDLINE" : ["-h"]
                              },
                   "PYTEST" : {
                                "DATABASEEXECUTOR" : "%RobotPythonPath%/Lib/site-packages/PyTestLog2DB/pytestlog2db.py",
-                              //  "LOCALCOMMANDLINE" : ["${server}", "${user}", "${password}", "${database}", "--UUID ${UUID}", "--config ${config}", "${append}", "${dryrun}"]
                                "LOCALCOMMANDLINE" : ["-h"]
                              }
                 }


### PR DESCRIPTION
Hi,

Please refer below changes in this pull request for issue #30 :
- Fix the issue [! LaTeX Error: File `tikzfill.image.sty' not found.](https://github.com/test-fullautomation/RobotFramework_AIO/actions/runs/4185321661/jobs/7252203298#step:7:422) when building doc on Windows in previous run.
- Add the **Test {OS} Package** jobs for installing and testing (run `aio-test-trigger.py`) built packages.
- Add the **Release AIO** job (is only trigger by new released tag) for creating Github Release and uploading built installer files to the Release. (Them can be downloaded without login requires - links can be used for our website)

Regarding to the  `aio-test-trigger.py`:
- Current test jobs are failed at **tutorial-test** component => an update to fix **tutorial-test** is required
- The internal component has been removed from `testtrigger_config.json` file
- *DATABASEEXECUTOR* is using mock files due to no OSS db now

Regarding to `pandoc` which is required for testing **python-genpackagedoc** component:
- On Linux, I have added it in the dependencies so that pandoc will be installed along with robotframework-aio on user machine (But I do not think it is good idea to install pandoc for user).
- On Windows, I have no idea to make it as the dependencies of robotframework-aio on Windows now. With testing job, I added the step **Install pandoc on Windows** to install it on test machine before executing `aio-test-trigger.py`.

Please give your opinions about this pandoc package.

Github workflow: https://github.com/test-fullautomation/RobotFramework_AIO/actions/runs/4230730722

Thank you,
Ngoan