### PR TITLE
Agt2hc/feat/robfw 366/replace robotframework excellib

### DIFF
--- a/build
+++ b/build
@@ -236,7 +236,8 @@ function parse_config () {
 					/usr/bin/yes | ${PYBIN} -m pip uninstall ${PACKNAME}
 					logresult "$?" "uninstalled ${PACKNAME}" "uninstall ${PACKNAME}"
 				fi
-				${PYBIN} ./setup.py clean --all install
+				${PYBIN} ./setup.py install
+				${PYBIN} ./setup.py clean --all
 				logresult "$?" "installed ${sec_name}" "install ${sec_name}"
 			fi
 		fi

--- a/config/RobotTest/RobotTest.code-workspace
+++ b/config/RobotTest/RobotTest.code-workspace
@@ -1,0 +1,17 @@
+{
+	"folders": [
+		{
+			"path": "./documentation"
+		},
+		{
+			"path": "./testcases"
+		},
+		{
+			"path": "./logfiles"
+		},
+		{
+			"path": "./tutorial"
+		}
+	],
+	"settings": {}
+}

--- a/config/repositories/repositories.conf
+++ b/config/repositories/repositories.conf
@@ -1,9 +1,3 @@
-; pypandoc in linux need to run setup.py with arguement before install
-[pypandoc]
-url=https://github.com/NicklasTegner/pypandoc
-name=pypandoc
-prebuild=build_pandoc_bin.sh
-
 [github]
 python-genpackagedoc=
 python-extensions-collection=
@@ -16,7 +10,11 @@ robotframework=
 robotframework-extensions-collection=
 robotframework-qconnect-base=
 robotframework-selftest=
-robotframework-testsuitesmanagement=
+[testsuit]
+   robotframework-testsuitesmanagement=
+   #this will run after python-genpackagedoc
+   prebuild=overwirte_version.sh
+
 robotframework-tutorial=
 robotframework-robotlog2rqm=
 robotframework-robotlog2db=

--- a/config/repositories/repositories.conf
+++ b/config/repositories/repositories.conf
@@ -10,10 +10,8 @@ robotframework=
 robotframework-extensions-collection=
 robotframework-qconnect-base=
 robotframework-selftest=
-[testsuit]
-   robotframework-testsuitesmanagement=
-   #this will run after python-genpackagedoc
-   prebuild=overwirte_version.sh
+robotframework-testsuitesmanagement=
+
 
 robotframework-tutorial=
 robotframework-robotlog2rqm=

--- a/install/python_requirements.txt
+++ b/install/python_requirements.txt
@@ -133,7 +133,7 @@ bokeh
 robotframework-robocop
 pylint
 #pandoc
-#pypandoc
+pypandoc_binary
 mobly
 pytest_mock
 odxtools

--- a/install/python_requirements.txt
+++ b/install/python_requirements.txt
@@ -100,7 +100,7 @@ robotframework-mqttlibrary
 robotframework-pythonlibcore  
 robotframework-requests       
 robotframework-sshlibrary     
-robotframework-excellibrary-xwfintech
+robotframework-excellib
 robotframework-seriallibrary
 schedule
 scp

--- a/install/python_requirements_lx.txt
+++ b/install/python_requirements_lx.txt
@@ -139,7 +139,7 @@ robotframework-robocop
 pylint
 Sphinx
 pandoc
-pypandoc
+pypandoc_binary
 mobly
 pytest_mock
 odxtools

--- a/install/python_requirements_lx.txt
+++ b/install/python_requirements_lx.txt
@@ -106,7 +106,7 @@ robotframework-mqttlibrary
 robotframework-pythonlibcore  
 robotframework-requests       
 robotframework-sshlibrary
-robotframework-excellibrary-xwfintech
+robotframework-excellib
 schedule
 scp
 # scapy

--- a/scripts/RobotFrameworkSetup.iss
+++ b/scripts/RobotFrameworkSetup.iss
@@ -222,6 +222,7 @@ var
   UsrDataDirPage: TInputDirWizardPage;
   ProjectPage : TWizardPage;
   ProjectListBox: TNewListBox;
+  PreviousUserDataDir: String;
 
 //
 // Maps a given ListPosition to a fix project index
@@ -528,7 +529,16 @@ begin
   
   //initialize user data directory page with last directory
   UsrDataDirPage.Values[0] := GetPreviousData('UsrDataDir',ExpandConstant('{sd}\RobotTest'));
+  PreviousUserDataDir := GetPreviousData('UsrDataDir',ExpandConstant(''));
 
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+begin
+  Result := True;
+  if ((CurPageID = UsrDataDirPage.ID) and not (CompareText(ExpandConstant(''), PreviousUserDataDir) = 0)and not  	 (CompareText(UsrDataDirPage.Values[0], PreviousUserDataDir) = 0)) then
+    Result := Msgbox('You selected new folder for Workspace. Old working files need to be add to vscodium workspace manually.' + #13#10 + 
+      'Are you sure you want to continue ?', mbInformation, MB_YESNO) = IDYES;
 end;
 
 //

--- a/test/aio-test-trigger/config/dbapp_config.json
+++ b/test/aio-test-trigger/config/dbapp_config.json
@@ -12,6 +12,6 @@
                      "RobLog2RQM"    : "robotframework-robotlog2rqm",
                      "TeSuitMa"      : "robotframework-testsuitesmanagement"
                   },
-   "version_sw" : "tt-version-201",
-   "variant"    : "tt-variant-201"
+   "version_sw" : "tt-version-207",
+   "variant"    : "tt-variant-207"
 }

--- a/test/aio-test-trigger/config/dbapp_config.json
+++ b/test/aio-test-trigger/config/dbapp_config.json
@@ -1,5 +1,5 @@
 {
-   "component"  : {
+   "components"  : {
                      "PyExColl"      : ["Comparison", "File", "Folder", "String", "Utils", "PythonExtensionsCollection"],
                      "GenPkgDoc"     : "GenPackageDoc",
                      "JPrePro"       : ["jsonpreprocessor", "JsonPreprocessor"],
@@ -11,7 +11,7 @@
                      "RobLog2DB"     : "robotframework-robotlog2db",
                      "RobLog2RQM"    : "robotframework-robotlog2rqm",
                      "TeSuitMa"      : "robotframework-testsuitesmanagement"
-                  },
-   "version_sw" : "tt-version-207",
-   "variant"    : "tt-variant-207"
+                   },
+   "version_sw" : "tt-version-211",
+   "variant"    : "tt-variant-211"
 }

--- a/test/aio-test-trigger/config/dbapp_config.json
+++ b/test/aio-test-trigger/config/dbapp_config.json
@@ -11,7 +11,5 @@
                      "RobLog2DB"     : "robotframework-robotlog2db",
                      "RobLog2RQM"    : "robotframework-robotlog2rqm",
                      "TeSuitMa"      : "robotframework-testsuitesmanagement"
-                   },
-   "version_sw" : "tt-version-211",
-   "variant"    : "tt-variant-211"
+                   }
 }

--- a/test/aio-test-trigger/config/testtrigger_config.json
+++ b/test/aio-test-trigger/config/testtrigger_config.json
@@ -2,7 +2,7 @@
 #
 # Test Trigger configuration file
 #
-# 23.02.2023
+# 01.03.2023
 #
 # **************************************************************************************************************
 # Format: extended json format with the possibility to comment out lines (by '#' at the beginning of the line).
@@ -142,7 +142,7 @@
 # The content of "LOCALCOMMANDLINE" is a list. Elements of this list can be parameters (${...}).
 # Values for parameters that are part of the "LOCALCOMMANDLINE" list, have to be defined in command line of Test Trigger (with --params).
 # Example: --params "param1=value1;param2=value2;...". This is optional.
-# Parameters of "LOCALCOMMANDLINE" that are not defined in command line, are skipped and therefore are not considered for test execution.
+# Parameters of "LOCALCOMMANDLINE" that are not defined in command line, are skipped and therefore are not considered for database access.
 # Finally (after internally the parameters are resolved) the "LOCALCOMMANDLINE" only contains parameters that are defined in the command line.
 # It is assumed that every value inside --params can be a string containing blanks. Nevertheless it is not necessary to encapsulate values in quotes.
 # The Test Trigger does this internally. Using also quotes inside --params most probably causes invalid command lines.
@@ -158,22 +158,23 @@
 # is a relative one, the Test Trigger converts the relative path to an absolute one internally. The reference is the position
 # of the Test Trigger (aio-test-trigger.py).
 #
-# Database access has to be activated explicitely in command line of Test Trigger by '--results2db'
+# Database access has to be activated explicitely in command line of Test Trigger by '--results2db'. Otherwise the execution of all
+# "DATABASEEXECUTOR" are skipped.
 
    "TESTTYPES" : {
                   "ROBOT"  : {
                                "DATABASEEXECUTOR" : "-m RobotLog2DB",
                                "LOCALCOMMANDLINE" : ["${server}", "${user}", "${password}", "${database}",
-                                                      # "--variant ${variant}",
-                                                      # "--versions ${versions}",
+                                                      "--variant ${variant}",
+                                                      "--versions ${versions}",
                                                       "--config ${dbapp_config}",
                                                       "${dryrun}"]
                              },
                   "PYTEST" : {
                                "DATABASEEXECUTOR" : "-m PyTestLog2DB",
                                "LOCALCOMMANDLINE" : ["${server}", "${user}", "${password}", "${database}",
-                                                     # "--variant ${variant}",    https://github.com/test-fullautomation/python-pytestlog2db/issues/14
-                                                     # "--versions ${versions}",  https://github.com/test-fullautomation/python-pytestlog2db/issues/14
+                                                     "--variant ${variant}",
+                                                     "--versions ${versions}",
                                                      "--config ${dbapp_config}",
                                                      "${dryrun}"]
                              }

--- a/test/aio-test-trigger/config/testtrigger_config.json
+++ b/test/aio-test-trigger/config/testtrigger_config.json
@@ -79,14 +79,13 @@
                        "TESTEXECUTOR"      : "executepytest.py",
                        "LOGFILE"           : "../../../../python-pytestlog2db/pytest/aiotestlogfiles/aiotestlogfile.xml"
                     },
-                    # to be restored after test is adapted to latest changes in testsuites management:
-                    # {
-                       # "COMPONENTROOTPATH" : "../../tutorial-test",
-                       # "TESTFOLDER"        : "pytest",
-                       # "TESTTYPE"          : "PYTEST",
-                       # "TESTEXECUTOR"      : "executepytest.py",
-                       # "LOGFILE"           : "../../tutorial-test/pytest/aiotestlogfiles/aiotestlogfile.xml"
-                    # },
+                    {
+                       "COMPONENTROOTPATH" : "../../tutorial-test",
+                       "TESTFOLDER"        : "pytest",
+                       "TESTTYPE"          : "PYTEST",
+                       "TESTEXECUTOR"      : "executepytest.py",
+                       "LOGFILE"           : "../../tutorial-test/pytest/aiotestlogfiles/aiotestlogfile.xml"
+                    },
                     {
                        "COMPONENTROOTPATH" : "../../../../robotframework-extensions-collection",
                        "TESTFOLDER"        : "test",

--- a/test/tutorial-test/playground/PlaygroundExecution.py
+++ b/test/tutorial-test/playground/PlaygroundExecution.py
@@ -95,7 +95,7 @@ sRobotFile_3    = CString.NormalizePath("./testsuites/exercise-pg-ts.robot", sRe
 sRobotFile_4    = CString.NormalizePath("./00000/exercise-pg-00000.robot", sReferencePathAbs=sReferencePath)
 sTestsuitesPath = CString.NormalizePath(r"./00000", sReferencePathAbs=sReferencePath)
 
-sSource = sRobotFile_1
+sSource = sRobotFile_2
 
 # local config
 # os.environ['ROBOT_LOCAL_CONFIG'] = f"..."

--- a/test/tutorial-test/playground/PlaygroundExecution.py
+++ b/test/tutorial-test/playground/PlaygroundExecution.py
@@ -89,9 +89,13 @@ sRobotFile_1    = CString.NormalizePath("./exercise-pg-1.robot", sReferencePathA
 sRobotFile_2    = CString.NormalizePath("./exercise-pg-2.robot", sReferencePathAbs=sReferencePath)
 # with variant configuration
 sRobotFile_3    = CString.NormalizePath("./testsuites/exercise-pg-ts.robot", sReferencePathAbs=sReferencePath)
-sTestsuitesPath = CString.NormalizePath("./testsuites", sReferencePathAbs=sReferencePath)
 
-sSource = sRobotFile_2
+# sTestsuitesPath = CString.NormalizePath("./testsuites", sReferencePathAbs=sReferencePath)
+
+sRobotFile_4    = CString.NormalizePath("./00000/exercise-pg-00000.robot", sReferencePathAbs=sReferencePath)
+sTestsuitesPath = CString.NormalizePath(r"./00000", sReferencePathAbs=sReferencePath)
+
+sSource = sRobotFile_1
 
 # local config
 # os.environ['ROBOT_LOCAL_CONFIG'] = f"..."
@@ -122,10 +126,11 @@ CONFIG_FILE  = None
 LOCAL_CONFIG = None
 #
 # METADATA    = "--metadata project:pg_variant2"
-# METADATA    = "--metadata version_sw:1.2.3"
-# METADATA    = "--metadata version_Hw:2.3.4"
+# METADATA    = "--metadata cmd_line_metadata:\"cmd_line_metadata_test_value\""
+# METADATA    = "--metadata version_sw:\"metadata_version_sw_in_command_line\""
+# METADATA    = "--metadata version_hw:2.3.4"
 # METADATA    = "--metadata version_test:3.4.5"
-# METADATA    = "--metadata version_sw:1.2.3 --metadata version_Hw:2.3.4 --metadata version_test:3.4.5"
+# METADATA    = "--metadata version_sw:1.2.3 --metadata version_hw:2.3.4 --metadata version_test:3.4.5"
 # METADATA    = "--metadata my_cmdline_metadata:my_cmdline_metadata_value"
 # METADATA    = "--metadata my_test_local_metadata:my_test_local_metadata_cmdline_value"
 # VARIABLE     = "--variable project:pg_variant2"
@@ -135,7 +140,7 @@ LOCAL_CONFIG = None
 # VARIABLE     = "--variable teststring_bench:\"command line test string bench\""
 # VARIABLE     = "--variable teststring_common:\"command line test string common\" --variable teststring_variant:\"command line test string variant\" --variable teststring_bench:\"command line test string bench\""
 # VARIANT      = "--variable variant:\"variant1\""
-VARIANT      = "--variable variant:\"variant2\""
+# VARIANT      = "--variable variant:\"variant2\""
 # VARIANT      = "--variable variant:\"inv/alid\""
 # VARIANT      = "--variable variant:\"    \""
 # VARIANT      = "--variable variant:\"SälfTest.ß.€.考.𠼭.𠼭\""
@@ -144,6 +149,7 @@ VARIANT      = "--variable variant:\"variant2\""
 # CONFIG_FILE  = "--variable config_file:\"./config/exercise-pg_config_variant2.json\""          # path relative to position of robot file
 # CONFIG_FILE  = "--variable config_file:\"./config/not_existing.json\""                         # path relative to position of robot file
 # CONFIG_FILE  = "--variable config_file:\"./localconfig/exercise-pg_localconfig_bench1.json\""  # path relative to position of robot file
+# CONFIG_FILE  = "--variable config_file:\"./config/exercise-pg_config_SälfTest.ß.€.考.𠼭.𠼭.json\""  # path relative to position of robot file
 # LOCAL_CONFIG = "--variable local_config:\"./localconfig/exercise-pg_localconfig_bench1.json\"" # path relative to position of robot file
 # LOCAL_CONFIG = "--variable local_config:\"./localconfig/exercise-pg_localconfig_bench2.json\"" # path relative to position of robot file
 # LOCAL_CONFIG = "--variable local_config:\"./localconfig/not_existing.json\""                   # path relative to position of robot file

--- a/test/tutorial-test/playground/exercise-pg-1.robot
+++ b/test/tutorial-test/playground/exercise-pg-1.robot
@@ -24,6 +24,8 @@ Library    RobotFramework_TestsuitesManagement    WITH NAME    tm
 Library    RobotframeworkExtensions.Collection    WITH NAME    rf.extensions
 
 Suite Setup    tm.testsuite_setup
+Test Setup    tm.testcase_setup
+Test Teardown    tm.testcase_teardown
 
 Metadata    version_hw    metadata_version_hw
 Metadata    my_test_local_metadata    my_test_local_metadata_value

--- a/test/tutorial-test/playground/exercise-pg-2.robot
+++ b/test/tutorial-test/playground/exercise-pg-2.robot
@@ -24,9 +24,11 @@ Library    RobotFramework_TestsuitesManagement    WITH NAME    tm
 Library    RobotframeworkExtensions.Collection    WITH NAME    rf.extensions
 
 Suite Setup    tm.testsuite_setup    ./config/exercise-pg_variants.json
+Test Setup    tm.testcase_setup
+Test Teardown    tm.testcase_teardown
 
-Metadata    version_hw    metadata_version_hw
-Metadata    my_test_local_metadata    my_test_local_metadata_value
+Metadata    version_hw    metadata_version_hw_within_file
+Metadata    my_test_local_metadata    my_test_local_metadata_value_within_file
 
 *** Test Cases ***
 Test Case exercise-pg-2

--- a/test/tutorial-test/playground/testsuites/component-A/feature-A-1/exercise-pg-feature-A-1-test.robot
+++ b/test/tutorial-test/playground/testsuites/component-A/feature-A-1/exercise-pg-feature-A-1-test.robot
@@ -20,6 +20,11 @@
 
 *** Settings ***
 
+Metadata    metadata-pg-feature-A-1    metadata-pg-feature-A-1-value
+
+Test Setup     tm.testcase_setup
+Test Teardown    tm.testcase_teardown
+
 *** Test Cases ***
 Test Case exercise-pg-feature-A-1-test
     [documentation]    exercise-pg-feature-A-1-test

--- a/test/tutorial-test/playground/testsuites/component-A/feature-A-2/exercise-pg-feature-A-2-test.robot
+++ b/test/tutorial-test/playground/testsuites/component-A/feature-A-2/exercise-pg-feature-A-2-test.robot
@@ -20,6 +20,12 @@
 
 *** Settings ***
 
+Metadata    metadata-pg-feature-A-2    metadata-pg-feature-A-2-value
+
+Test Setup     tm.testcase_setup
+Test Teardown    tm.testcase_teardown
+
+
 *** Test Cases ***
 Test Case exercise-pg-feature-A-2-test
     [documentation]    exercise-pg-feature-A-2-test

--- a/test/tutorial-test/playground/testsuites/component-B/feature-B-1/exercise-pg-feature-B-1-test.robot
+++ b/test/tutorial-test/playground/testsuites/component-B/feature-B-1/exercise-pg-feature-B-1-test.robot
@@ -20,6 +20,12 @@
 
 *** Settings ***
 
+Metadata    metadata-pg-feature-B-1    metadata-pg-feature-B-1-value
+
+Test Setup     tm.testcase_setup
+Test Teardown    tm.testcase_teardown
+
+
 *** Test Cases ***
 Test Case exercise-pg-feature-B-1-test
     [documentation]    exercise-pg-feature-B-1-test

--- a/test/tutorial-test/playground/testsuites/component-B/feature-B-2/exercise-pg-feature-B-2-test.robot
+++ b/test/tutorial-test/playground/testsuites/component-B/feature-B-2/exercise-pg-feature-B-2-test.robot
@@ -20,6 +20,11 @@
 
 *** Settings ***
 
+Metadata    metadata-pg-feature-B-2    metadata-pg-feature-B-2-value
+
+Test Setup     tm.testcase_setup
+Test Teardown    tm.testcase_teardown
+
 *** Test Cases ***
 Test Case exercise-pg-feature-B-2-test
     [documentation]    exercise-pg-feature-B-2-test

--- a/test/tutorial-test/playground/testsuites/exercise-pg-ts.robot
+++ b/test/tutorial-test/playground/testsuites/exercise-pg-ts.robot
@@ -20,6 +20,12 @@
 
 *** Settings ***
 
+Metadata    metadata-pg-ts    metadata-pg-ts-value-top-level-robot-file
+
+Test Setup     tm.testcase_setup
+Test Teardown    tm.testcase_teardown
+
+
 *** Test Cases ***
 Test Case exercise-pg-ts
     [documentation]    exercise-pg-ts

--- a/test/tutorial-test/referencelogfiles/testsuites-E01-01/exercise-01.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E01-01/exercise-01.log
@@ -1,35 +1,36 @@
 ==============================================================================
-20230118 14:34:07.778 - INFO - + START SUITE: Exercise-01 [ ]
+20230227 15:09:53.125 - INFO - + START SUITE: Exercise-01 [ ]
 ==============================================================================
-20230118 14:34:07.786 - INFO - +- START SETUP: tm.Testsuite Setup [ ]
-20230118 14:34:07.806 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
-20230118 14:34:07.806 - INFO - Set suite metadata 'version_sw' to value ''.
-20230118 14:34:07.806 - INFO - Set suite metadata 'version_hw' to value ''.
-20230118 14:34:07.806 - INFO - Set suite metadata 'version_test' to value ''.
-20230118 14:34:07.806 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
-20230118 14:34:07.808 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
-20230118 14:34:07.808 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
-20230118 14:34:07.808 - INFO - Set suite metadata 'version' to value '0.6.0'.
-20230118 14:34:07.809 - INFO - ${CONFIG} = {'Project': 'RobotFramework Testsuites', 'WelcomeString': 'Hello... RobotFramework AIO is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'version': {'majorversion': '0', 'minor...
-20230118 14:34:07.809 - WARN - Running with configuration level 4! 
+20230227 15:09:53.137 - INFO - +- START SETUP: tm.Testsuite Setup [ ]
+20230227 15:09:53.161 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
+20230227 15:09:53.161 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
+20230227 15:09:53.163 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
+20230227 15:09:53.163 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
+20230227 15:09:53.163 - INFO - Set suite metadata 'version' to value '0.6.0'.
+20230227 15:09:53.163 - INFO - Set suite metadata 'version_sw' to value ''.
+20230227 15:09:53.163 - INFO - Set suite metadata 'version_hw' to value ''.
+20230227 15:09:53.163 - INFO - Set suite metadata 'version_test' to value ''.
+20230227 15:09:53.164 - INFO - ${CONFIG} = {'Project': 'RobotFramework Testsuites', 'WelcomeString': 'Hello... RobotFramework AIO is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'version': {'majorversion': '0', 'minor...
+20230227 15:09:53.164 - WARN - Running with configuration level 4! 
 Selected configuration file 'D:\RobotFramework\python39\lib\site-packages\RobotFramework_TestsuitesManagement\Config\robot_config.json'
-20230118 14:34:07.810 - INFO - Suite Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-01\
-20230118 14:34:07.810 - INFO - CfgFile Path: D:\RobotFramework\python39\lib\site-packages\RobotFramework_TestsuitesManagement\Config\robot_config.json
-20230118 14:34:07.810 - INFO - Suite Count: 1
-20230118 14:34:07.810 - INFO - Total testcases in TestSuite Exercise-01 is: 1
-20230118 14:34:07.810 - INFO - +- END SETUP: tm.Testsuite Setup (24)
+20230227 15:09:53.165 - INFO - Robot Framework AIO version check passed!
+20230227 15:09:53.165 - INFO - Suite Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-01\'
+20230227 15:09:53.165 - INFO - CfgFile Path: 'D:\RobotFramework\python39\lib\site-packages\RobotFramework_TestsuitesManagement\Config\robot_config.json'
+20230227 15:09:53.165 - INFO - Number of test suites: 1
+20230227 15:09:53.165 - INFO - Total number of testcases: 1
+20230227 15:09:53.165 - INFO - +- END SETUP: tm.Testsuite Setup (28)
 ------------------------------------------------------------------------------
-20230118 14:34:07.810 - INFO - +- START TEST: Test Case exercise-01 [ ]
+20230227 15:09:53.166 - INFO - +- START TEST: Test Case exercise-01 [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:07.812 - INFO - +-- START KEYWORD: BuiltIn.Log [ Maximum_version : ${CONFIG}[Maximum_version] | console=yes ]
-20230118 14:34:07.812 - INFO - Maximum_version : 1.0.0
-20230118 14:34:07.819 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
+20230227 15:09:53.166 - INFO - +-- START KEYWORD: BuiltIn.Log [ Maximum_version : ${CONFIG}[Maximum_version] | console=yes ]
+20230227 15:09:53.167 - INFO - Maximum_version : 1.0.0
+20230227 15:09:53.167 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-20230118 14:34:07.820 - INFO - +-- START KEYWORD: BuiltIn.Log [ Project : ${CONFIG}[Project] | console=yes ]
-20230118 14:34:07.820 - INFO - Project : RobotFramework Testsuites
-20230118 14:34:07.821 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
+20230227 15:09:53.168 - INFO - +-- START KEYWORD: BuiltIn.Log [ Project : ${CONFIG}[Project] | console=yes ]
+20230227 15:09:53.168 - INFO - Project : RobotFramework Testsuites
+20230227 15:09:53.169 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ------------------------------------------------------------------------------
-20230118 14:34:07.825 - INFO - +- END TEST: Test Case exercise-01 (11)
+20230227 15:09:53.170 - INFO - +- END TEST: Test Case exercise-01 (4)
 ------------------------------------------------------------------------------
-20230118 14:34:07.829 - INFO - + END SUITE: Exercise-01 (141)
+20230227 15:09:53.173 - INFO - + END SUITE: Exercise-01 (148)
 ==============================================================================

--- a/test/tutorial-test/referencelogfiles/testsuites-E02-01/exercise-02.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E02-01/exercise-02.log
@@ -1,23 +1,22 @@
 ==============================================================================
-20230118 14:34:08.250 - INFO - + START SUITE: Exercise-02 [ ]
+20230227 15:09:53.631 - INFO - + START SUITE: Exercise-02 [ ]
 ==============================================================================
-20230118 14:34:08.277 - INFO - +- START SETUP: tm.Testsuite Setup [ ]
-20230118 14:34:08.277 - WARN - Running with configuration level 1! 
-Selected configuration file 'C:\RobotTest\tutorial\900_building_testsuites\exercise-02\config\exercise-02_config_variant1.json'
-20230118 14:34:08.278 - INFO - Running with configuration level 1
-20230118 14:34:08.278 - INFO - Suite Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-02\
-20230118 14:34:08.278 - INFO - CfgFile Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-02\config\exercise-02_config_variant1.json
-20230118 14:34:08.278 - INFO - Suite Count: 1
-20230118 14:34:08.278 - INFO - Total testcases in TestSuite Exercise-02 is: 1
-20230118 14:34:08.278 - INFO - +- END SETUP: tm.Testsuite Setup (1)
+20230227 15:09:53.662 - INFO - +- START SETUP: tm.Testsuite Setup [ ]
+20230227 15:09:53.662 - INFO - Running with configuration level 1
+20230227 15:09:53.662 - INFO - Robot Framework AIO version check passed!
+20230227 15:09:53.662 - INFO - Suite Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-02\'
+20230227 15:09:53.662 - INFO - CfgFile Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-02\config\exercise-02_config_variant1.json'
+20230227 15:09:53.662 - INFO - Number of test suites: 1
+20230227 15:09:53.663 - INFO - Total number of testcases: 1
+20230227 15:09:53.663 - INFO - +- END SETUP: tm.Testsuite Setup (1)
 ------------------------------------------------------------------------------
-20230118 14:34:08.278 - INFO - +- START TEST: Test Case exercise-02 [ ]
+20230227 15:09:53.663 - INFO - +- START TEST: Test Case exercise-02 [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:08.280 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
-20230118 14:34:08.280 - INFO - teststring : I am the 'variant1' configuration of exercise 02
-20230118 14:34:08.282 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
+20230227 15:09:53.664 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:09:53.664 - INFO - teststring : I am the 'variant1' configuration of exercise 02
+20230227 15:09:53.665 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ------------------------------------------------------------------------------
-20230118 14:34:08.284 - INFO - +- END TEST: Test Case exercise-02 (5)
+20230227 15:09:53.669 - INFO - +- END TEST: Test Case exercise-02 (2)
 ------------------------------------------------------------------------------
-20230118 14:34:08.291 - INFO - + END SUITE: Exercise-02 (131)
+20230227 15:09:53.671 - INFO - + END SUITE: Exercise-02 (141)
 ==============================================================================

--- a/test/tutorial-test/referencelogfiles/testsuites-E02-02/exercise-02.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E02-02/exercise-02.log
@@ -1,32 +1,33 @@
 ==============================================================================
-20230118 14:34:08.716 - INFO - + START SUITE: exercise-02-B [ ]
+20230227 15:09:54.127 - INFO - + START SUITE: exercise-02-B [ ]
 ==============================================================================
-20230118 14:34:08.723 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-02_variants.json ]
-20230118 14:34:08.744 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
-20230118 14:34:08.744 - INFO - Set suite metadata 'version_sw' to value ''.
-20230118 14:34:08.744 - INFO - Set suite metadata 'version_hw' to value ''.
-20230118 14:34:08.744 - INFO - Set suite metadata 'version_test' to value ''.
-20230118 14:34:08.744 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
-20230118 14:34:08.745 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
-20230118 14:34:08.745 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
-20230118 14:34:08.746 - INFO - Set suite metadata 'version' to value '0.6.0'.
-20230118 14:34:08.746 - INFO - ${teststring} = I am the 'default' variant configuration of exercise 02
-20230118 14:34:08.747 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
-20230118 14:34:08.747 - INFO - Running with configuration level 2
-20230118 14:34:08.747 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-02\config\exercise-02_config_default.json'
-20230118 14:34:08.747 - INFO - Suite Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-02\
-20230118 14:34:08.747 - INFO - CfgFile Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-02\config\exercise-02_config_default.json
-20230118 14:34:08.747 - INFO - Suite Count: 1
-20230118 14:34:08.747 - INFO - Total testcases in TestSuite exercise-02-B is: 1
-20230118 14:34:08.747 - INFO - +- END SETUP: tm.Testsuite Setup (24)
+20230227 15:09:54.135 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-02_variants.json ]
+20230227 15:09:54.168 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
+20230227 15:09:54.169 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
+20230227 15:09:54.170 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
+20230227 15:09:54.171 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
+20230227 15:09:54.171 - INFO - Set suite metadata 'version' to value '0.6.0'.
+20230227 15:09:54.171 - INFO - Set suite metadata 'version_sw' to value ''.
+20230227 15:09:54.171 - INFO - Set suite metadata 'version_hw' to value ''.
+20230227 15:09:54.171 - INFO - Set suite metadata 'version_test' to value ''.
+20230227 15:09:54.171 - INFO - ${teststring} = I am the 'default' variant configuration of exercise 02
+20230227 15:09:54.172 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
+20230227 15:09:54.172 - INFO - Running with configuration level 2
+20230227 15:09:54.172 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-02\config\exercise-02_config_default.json'
+20230227 15:09:54.172 - INFO - Robot Framework AIO version check passed!
+20230227 15:09:54.173 - INFO - Suite Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-02\'
+20230227 15:09:54.173 - INFO - CfgFile Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-02\config\exercise-02_config_default.json'
+20230227 15:09:54.173 - INFO - Number of test suites: 1
+20230227 15:09:54.173 - INFO - Total number of testcases: 1
+20230227 15:09:54.173 - INFO - +- END SETUP: tm.Testsuite Setup (38)
 ------------------------------------------------------------------------------
-20230118 14:34:08.748 - INFO - +- START TEST: Test Case exercise-02-B [ ]
+20230227 15:09:54.173 - INFO - +- START TEST: Test Case exercise-02-B [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:08.749 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
-20230118 14:34:08.749 - INFO - teststring : I am the 'default' variant configuration of exercise 02
-20230118 14:34:08.749 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
+20230227 15:09:54.174 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:09:54.174 - INFO - teststring : I am the 'default' variant configuration of exercise 02
+20230227 15:09:54.175 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
 ------------------------------------------------------------------------------
-20230118 14:34:08.753 - INFO - +- END TEST: Test Case exercise-02-B (2)
+20230227 15:09:54.177 - INFO - +- END TEST: Test Case exercise-02-B (2)
 ------------------------------------------------------------------------------
-20230118 14:34:08.755 - INFO - + END SUITE: exercise-02-B (130)
+20230227 15:09:54.180 - INFO - + END SUITE: exercise-02-B (152)
 ==============================================================================

--- a/test/tutorial-test/referencelogfiles/testsuites-E02-03/exercise-02.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E02-03/exercise-02.log
@@ -1,32 +1,33 @@
 ==============================================================================
-20230118 14:34:09.172 - INFO - + START SUITE: exercise-02-B [ ]
+20230227 15:09:54.657 - INFO - + START SUITE: exercise-02-B [ ]
 ==============================================================================
-20230118 14:34:09.184 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-02_variants.json ]
-20230118 14:34:09.206 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
-20230118 14:34:09.207 - INFO - Set suite metadata 'version_sw' to value ''.
-20230118 14:34:09.207 - INFO - Set suite metadata 'version_hw' to value ''.
-20230118 14:34:09.207 - INFO - Set suite metadata 'version_test' to value ''.
-20230118 14:34:09.207 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
-20230118 14:34:09.208 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
-20230118 14:34:09.209 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
-20230118 14:34:09.209 - INFO - Set suite metadata 'version' to value '0.6.0'.
-20230118 14:34:09.209 - INFO - ${teststring} = I am the 'variant2' configuration of exercise 02
-20230118 14:34:09.210 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
-20230118 14:34:09.210 - INFO - Running with configuration level 2
-20230118 14:34:09.210 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-02\config\exercise-02_config_variant2.json'
-20230118 14:34:09.210 - INFO - Suite Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-02\
-20230118 14:34:09.210 - INFO - CfgFile Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-02\config\exercise-02_config_variant2.json
-20230118 14:34:09.210 - INFO - Suite Count: 1
-20230118 14:34:09.210 - INFO - Total testcases in TestSuite exercise-02-B is: 1
-20230118 14:34:09.210 - INFO - +- END SETUP: tm.Testsuite Setup (26)
+20230227 15:09:54.664 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-02_variants.json ]
+20230227 15:09:54.691 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
+20230227 15:09:54.691 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
+20230227 15:09:54.694 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
+20230227 15:09:54.694 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
+20230227 15:09:54.694 - INFO - Set suite metadata 'version' to value '0.6.0'.
+20230227 15:09:54.694 - INFO - Set suite metadata 'version_sw' to value ''.
+20230227 15:09:54.694 - INFO - Set suite metadata 'version_hw' to value ''.
+20230227 15:09:54.694 - INFO - Set suite metadata 'version_test' to value ''.
+20230227 15:09:54.695 - INFO - ${teststring} = I am the 'variant2' configuration of exercise 02
+20230227 15:09:54.695 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
+20230227 15:09:54.695 - INFO - Running with configuration level 2
+20230227 15:09:54.695 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-02\config\exercise-02_config_variant2.json'
+20230227 15:09:54.696 - INFO - Robot Framework AIO version check passed!
+20230227 15:09:54.696 - INFO - Suite Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-02\'
+20230227 15:09:54.696 - INFO - CfgFile Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-02\config\exercise-02_config_variant2.json'
+20230227 15:09:54.696 - INFO - Number of test suites: 1
+20230227 15:09:54.696 - INFO - Total number of testcases: 1
+20230227 15:09:54.696 - INFO - +- END SETUP: tm.Testsuite Setup (32)
 ------------------------------------------------------------------------------
-20230118 14:34:09.211 - INFO - +- START TEST: Test Case exercise-02-B [ ]
+20230227 15:09:54.696 - INFO - +- START TEST: Test Case exercise-02-B [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:09.212 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
-20230118 14:34:09.212 - INFO - teststring : I am the 'variant2' configuration of exercise 02
-20230118 14:34:09.213 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
+20230227 15:09:54.697 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:09:54.697 - INFO - teststring : I am the 'variant2' configuration of exercise 02
+20230227 15:09:54.698 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
 ------------------------------------------------------------------------------
-20230118 14:34:09.214 - INFO - +- END TEST: Test Case exercise-02-B (3)
+20230227 15:09:54.700 - INFO - +- END TEST: Test Case exercise-02-B (2)
 ------------------------------------------------------------------------------
-20230118 14:34:09.216 - INFO - + END SUITE: exercise-02-B (138)
+20230227 15:09:54.702 - INFO - + END SUITE: exercise-02-B (148)
 ==============================================================================

--- a/test/tutorial-test/referencelogfiles/testsuites-E03-01/exercise-03.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E03-01/exercise-03.log
@@ -1,32 +1,33 @@
 ==============================================================================
-20230118 14:34:09.626 - INFO - + START SUITE: Exercise-03 [ ]
+20230227 15:09:55.174 - INFO - + START SUITE: Exercise-03 [ ]
 ==============================================================================
-20230118 14:34:09.637 - INFO - +- START SETUP: tm.Testsuite Setup [ ]
-20230118 14:34:09.667 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
-20230118 14:34:09.667 - INFO - Set suite metadata 'version_sw' to value ''.
-20230118 14:34:09.667 - INFO - Set suite metadata 'version_hw' to value ''.
-20230118 14:34:09.667 - INFO - Set suite metadata 'version_test' to value ''.
-20230118 14:34:09.667 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
-20230118 14:34:09.669 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
-20230118 14:34:09.669 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
-20230118 14:34:09.669 - INFO - Set suite metadata 'version' to value '0.6.0'.
-20230118 14:34:09.670 - INFO - ${teststring} = I am the 'robot_config' configuration of exercise 03
-20230118 14:34:09.670 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
-20230118 14:34:09.670 - INFO - Running with configuration level 3
-20230118 14:34:09.670 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-03\config\robot_config.json'
-20230118 14:34:09.670 - INFO - Suite Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-03\
-20230118 14:34:09.671 - INFO - CfgFile Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-03\config\robot_config.json
-20230118 14:34:09.671 - INFO - Suite Count: 1
-20230118 14:34:09.671 - INFO - Total testcases in TestSuite Exercise-03 is: 1
-20230118 14:34:09.671 - INFO - +- END SETUP: tm.Testsuite Setup (34)
+20230227 15:09:55.182 - INFO - +- START SETUP: tm.Testsuite Setup [ ]
+20230227 15:09:55.207 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
+20230227 15:09:55.207 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
+20230227 15:09:55.209 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
+20230227 15:09:55.209 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
+20230227 15:09:55.209 - INFO - Set suite metadata 'version' to value '0.6.0'.
+20230227 15:09:55.209 - INFO - Set suite metadata 'version_sw' to value ''.
+20230227 15:09:55.209 - INFO - Set suite metadata 'version_hw' to value ''.
+20230227 15:09:55.209 - INFO - Set suite metadata 'version_test' to value ''.
+20230227 15:09:55.210 - INFO - ${teststring} = I am the 'robot_config' configuration of exercise 03
+20230227 15:09:55.210 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
+20230227 15:09:55.210 - INFO - Running with configuration level 3
+20230227 15:09:55.210 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-03\config\robot_config.json'
+20230227 15:09:55.210 - INFO - Robot Framework AIO version check passed!
+20230227 15:09:55.211 - INFO - Suite Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-03\'
+20230227 15:09:55.211 - INFO - CfgFile Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-03\config\robot_config.json'
+20230227 15:09:55.211 - INFO - Number of test suites: 1
+20230227 15:09:55.211 - INFO - Total number of testcases: 1
+20230227 15:09:55.211 - INFO - +- END SETUP: tm.Testsuite Setup (29)
 ------------------------------------------------------------------------------
-20230118 14:34:09.671 - INFO - +- START TEST: Test Case exercise-03 [ ]
+20230227 15:09:55.211 - INFO - +- START TEST: Test Case exercise-03 [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:09.672 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
-20230118 14:34:09.672 - INFO - teststring : I am the 'robot_config' configuration of exercise 03
-20230118 14:34:09.673 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
+20230227 15:09:55.212 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:09:55.212 - INFO - teststring : I am the 'robot_config' configuration of exercise 03
+20230227 15:09:55.214 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ------------------------------------------------------------------------------
-20230118 14:34:09.675 - INFO - +- END TEST: Test Case exercise-03 (2)
+20230227 15:09:55.223 - INFO - +- END TEST: Test Case exercise-03 (3)
 ------------------------------------------------------------------------------
-20230118 14:34:09.677 - INFO - + END SUITE: Exercise-03 (145)
+20230227 15:09:55.228 - INFO - + END SUITE: Exercise-03 (153)
 ==============================================================================

--- a/test/tutorial-test/referencelogfiles/testsuites-E03-02/exercise-03.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E03-02/exercise-03.log
@@ -1,32 +1,33 @@
 ==============================================================================
-20230118 14:34:10.085 - INFO - + START SUITE: exercise-03-A [ ]
+20230227 15:09:55.721 - INFO - + START SUITE: exercise-03-A [ ]
 ==============================================================================
-20230118 14:34:10.092 - INFO - +- START SETUP: tm.Testsuite Setup [ ]
-20230118 14:34:10.113 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
-20230118 14:34:10.114 - INFO - Set suite metadata 'version_sw' to value ''.
-20230118 14:34:10.114 - INFO - Set suite metadata 'version_hw' to value ''.
-20230118 14:34:10.114 - INFO - Set suite metadata 'version_test' to value ''.
-20230118 14:34:10.114 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
-20230118 14:34:10.115 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
-20230118 14:34:10.115 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
-20230118 14:34:10.116 - INFO - Set suite metadata 'version' to value '0.6.0'.
-20230118 14:34:10.116 - INFO - ${teststring} = I am the 'exercise-03-A' configuration of exercise 03
-20230118 14:34:10.117 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
-20230118 14:34:10.117 - INFO - Running with configuration level 3
-20230118 14:34:10.117 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-03\config\exercise-03-A.json'
-20230118 14:34:10.117 - INFO - Suite Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-03\
-20230118 14:34:10.117 - INFO - CfgFile Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-03\config\exercise-03-A.json
-20230118 14:34:10.117 - INFO - Suite Count: 1
-20230118 14:34:10.117 - INFO - Total testcases in TestSuite exercise-03-A is: 1
-20230118 14:34:10.117 - INFO - +- END SETUP: tm.Testsuite Setup (25)
+20230227 15:09:55.729 - INFO - +- START SETUP: tm.Testsuite Setup [ ]
+20230227 15:09:55.752 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
+20230227 15:09:55.752 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
+20230227 15:09:55.754 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
+20230227 15:09:55.754 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
+20230227 15:09:55.754 - INFO - Set suite metadata 'version' to value '0.6.0'.
+20230227 15:09:55.754 - INFO - Set suite metadata 'version_sw' to value ''.
+20230227 15:09:55.755 - INFO - Set suite metadata 'version_hw' to value ''.
+20230227 15:09:55.755 - INFO - Set suite metadata 'version_test' to value ''.
+20230227 15:09:55.755 - INFO - ${teststring} = I am the 'exercise-03-A' configuration of exercise 03
+20230227 15:09:55.756 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
+20230227 15:09:55.756 - INFO - Running with configuration level 3
+20230227 15:09:55.756 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-03\config\exercise-03-A.json'
+20230227 15:09:55.756 - INFO - Robot Framework AIO version check passed!
+20230227 15:09:55.756 - INFO - Suite Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-03\'
+20230227 15:09:55.756 - INFO - CfgFile Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-03\config\exercise-03-A.json'
+20230227 15:09:55.756 - INFO - Number of test suites: 1
+20230227 15:09:55.756 - INFO - Total number of testcases: 1
+20230227 15:09:55.756 - INFO - +- END SETUP: tm.Testsuite Setup (27)
 ------------------------------------------------------------------------------
-20230118 14:34:10.117 - INFO - +- START TEST: Test Case exercise-03-A [ ]
+20230227 15:09:55.757 - INFO - +- START TEST: Test Case exercise-03-A [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:10.119 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
-20230118 14:34:10.119 - INFO - teststring : I am the 'exercise-03-A' configuration of exercise 03
-20230118 14:34:10.120 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
+20230227 15:09:55.758 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:09:55.758 - INFO - teststring : I am the 'exercise-03-A' configuration of exercise 03
+20230227 15:09:55.759 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ------------------------------------------------------------------------------
-20230118 14:34:10.123 - INFO - +- END TEST: Test Case exercise-03-A (3)
+20230227 15:09:55.761 - INFO - +- END TEST: Test Case exercise-03-A (2)
 ------------------------------------------------------------------------------
-20230118 14:34:10.126 - INFO - + END SUITE: exercise-03-A (131)
+20230227 15:09:55.763 - INFO - + END SUITE: exercise-03-A (146)
 ==============================================================================

--- a/test/tutorial-test/referencelogfiles/testsuites-E03-03/exercise-03.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E03-03/exercise-03.log
@@ -1,32 +1,33 @@
 ==============================================================================
-20230118 14:34:10.544 - INFO - + START SUITE: exercise-03-B [ ]
+20230227 15:09:56.229 - INFO - + START SUITE: exercise-03-B [ ]
 ==============================================================================
-20230118 14:34:10.548 - INFO - +- START SETUP: tm.Testsuite Setup [ ]
-20230118 14:34:10.568 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
-20230118 14:34:10.568 - INFO - Set suite metadata 'version_sw' to value ''.
-20230118 14:34:10.568 - INFO - Set suite metadata 'version_hw' to value ''.
-20230118 14:34:10.568 - INFO - Set suite metadata 'version_test' to value ''.
-20230118 14:34:10.569 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
-20230118 14:34:10.570 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
-20230118 14:34:10.570 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
-20230118 14:34:10.571 - INFO - Set suite metadata 'version' to value '0.6.0'.
-20230118 14:34:10.571 - INFO - ${teststring} = I am the 'exercise-03-B' configuration of exercise 03
-20230118 14:34:10.572 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
-20230118 14:34:10.572 - INFO - Running with configuration level 3
-20230118 14:34:10.572 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-03\config\exercise-03-B.json'
-20230118 14:34:10.573 - INFO - Suite Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-03\
-20230118 14:34:10.573 - INFO - CfgFile Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-03\config\exercise-03-B.json
-20230118 14:34:10.573 - INFO - Suite Count: 1
-20230118 14:34:10.573 - INFO - Total testcases in TestSuite exercise-03-B is: 1
-20230118 14:34:10.573 - INFO - +- END SETUP: tm.Testsuite Setup (25)
+20230227 15:09:56.236 - INFO - +- START SETUP: tm.Testsuite Setup [ ]
+20230227 15:09:56.259 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
+20230227 15:09:56.259 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
+20230227 15:09:56.262 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
+20230227 15:09:56.262 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
+20230227 15:09:56.262 - INFO - Set suite metadata 'version' to value '0.6.0'.
+20230227 15:09:56.262 - INFO - Set suite metadata 'version_sw' to value ''.
+20230227 15:09:56.262 - INFO - Set suite metadata 'version_hw' to value ''.
+20230227 15:09:56.262 - INFO - Set suite metadata 'version_test' to value ''.
+20230227 15:09:56.263 - INFO - ${teststring} = I am the 'exercise-03-B' configuration of exercise 03
+20230227 15:09:56.263 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
+20230227 15:09:56.263 - INFO - Running with configuration level 3
+20230227 15:09:56.263 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-03\config\exercise-03-B.json'
+20230227 15:09:56.263 - INFO - Robot Framework AIO version check passed!
+20230227 15:09:56.264 - INFO - Suite Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-03\'
+20230227 15:09:56.264 - INFO - CfgFile Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-03\config\exercise-03-B.json'
+20230227 15:09:56.264 - INFO - Number of test suites: 1
+20230227 15:09:56.264 - INFO - Total number of testcases: 1
+20230227 15:09:56.264 - INFO - +- END SETUP: tm.Testsuite Setup (28)
 ------------------------------------------------------------------------------
-20230118 14:34:10.574 - INFO - +- START TEST: Test Case exercise-03-B [ ]
+20230227 15:09:56.264 - INFO - +- START TEST: Test Case exercise-03-B [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:10.575 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
-20230118 14:34:10.575 - INFO - teststring : I am the 'exercise-03-B' configuration of exercise 03
-20230118 14:34:10.576 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
+20230227 15:09:56.265 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:09:56.265 - INFO - teststring : I am the 'exercise-03-B' configuration of exercise 03
+20230227 15:09:56.266 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ------------------------------------------------------------------------------
-20230118 14:34:10.579 - INFO - +- END TEST: Test Case exercise-03-B (3)
+20230227 15:09:56.273 - INFO - +- END TEST: Test Case exercise-03-B (2)
 ------------------------------------------------------------------------------
-20230118 14:34:10.582 - INFO - + END SUITE: exercise-03-B (131)
+20230227 15:09:56.276 - INFO - + END SUITE: exercise-03-B (153)
 ==============================================================================

--- a/test/tutorial-test/referencelogfiles/testsuites-E04-01/exercise-04.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E04-01/exercise-04.log
@@ -1,100 +1,101 @@
 ==============================================================================
-20230118 14:34:11.004 - INFO - + START SUITE: Testsuites [ ]
+20230227 15:09:56.751 - INFO - + START SUITE: Testsuites [ ]
 ==============================================================================
-20230118 14:34:11.011 - INFO - +- START SETUP: tm.Testsuite Setup [ ../config/exercise-04_variants.json ]
-20230118 14:34:11.031 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
-20230118 14:34:11.032 - INFO - Set suite metadata 'version_sw' to value ''.
-20230118 14:34:11.032 - INFO - Set suite metadata 'version_hw' to value ''.
-20230118 14:34:11.032 - INFO - Set suite metadata 'version_test' to value ''.
-20230118 14:34:11.032 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
-20230118 14:34:11.033 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
-20230118 14:34:11.033 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
-20230118 14:34:11.034 - INFO - Set suite metadata 'version' to value '0.6.0'.
-20230118 14:34:11.034 - INFO - ${teststring} = I am the 'variant2' configuration of exercise 04
-20230118 14:34:11.035 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
-20230118 14:34:11.035 - INFO - Running with configuration level 2
-20230118 14:34:11.035 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-04\config\exercise-04_config_variant2.json'
-20230118 14:34:11.035 - INFO - Suite Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-04\testsuites
-20230118 14:34:11.035 - INFO - CfgFile Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-04\config\exercise-04_config_variant2.json
-20230118 14:34:11.035 - INFO - Suite Count: 1
-20230118 14:34:11.035 - INFO - Total testcases in TestSuite Testsuites is: 5
-20230118 14:34:11.035 - INFO - +- END SETUP: tm.Testsuite Setup (24)
+20230227 15:09:56.755 - INFO - +- START SETUP: tm.Testsuite Setup [ ../config/exercise-04_variants.json ]
+20230227 15:09:56.786 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
+20230227 15:09:56.786 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
+20230227 15:09:56.787 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
+20230227 15:09:56.788 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
+20230227 15:09:56.788 - INFO - Set suite metadata 'version' to value '0.6.0'.
+20230227 15:09:56.788 - INFO - Set suite metadata 'version_sw' to value ''.
+20230227 15:09:56.788 - INFO - Set suite metadata 'version_hw' to value ''.
+20230227 15:09:56.788 - INFO - Set suite metadata 'version_test' to value ''.
+20230227 15:09:56.788 - INFO - ${teststring} = I am the 'variant2' configuration of exercise 04
+20230227 15:09:56.789 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
+20230227 15:09:56.789 - INFO - Running with configuration level 2
+20230227 15:09:56.789 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-04\config\exercise-04_config_variant2.json'
+20230227 15:09:56.789 - INFO - Robot Framework AIO version check passed!
+20230227 15:09:56.789 - INFO - Suite Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-04\testsuites'
+20230227 15:09:56.789 - INFO - CfgFile Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-04\config\exercise-04_config_variant2.json'
+20230227 15:09:56.789 - INFO - Number of test suites: 1
+20230227 15:09:56.790 - INFO - Total number of testcases: 5
+20230227 15:09:56.790 - INFO - +- END SETUP: tm.Testsuite Setup (35)
 ==============================================================================
-20230118 14:34:11.037 - INFO - +- START SUITE: Testsuites.001 [ ]
+20230227 15:09:56.791 - INFO - +- START SUITE: Testsuites.001 [ ]
 ==============================================================================
-20230118 14:34:11.040 - INFO - +-- START SUITE: Testsuites.001.001-01 [ ]
+20230227 15:09:56.795 - INFO - +-- START SUITE: Testsuites.001.001-01 [ ]
 ==============================================================================
-20230118 14:34:11.048 - INFO - +--- START SUITE: Testsuites.001.001-01.001-01-01 [ ]
+20230227 15:09:56.799 - INFO - +--- START SUITE: Testsuites.001.001-01.001-01-01 [ ]
 ==============================================================================
-20230118 14:34:11.050 - INFO - +---- START SUITE: Testsuites.001.001-01.001-01-01.Exercise-04-001-01-01 [ ]
+20230227 15:09:56.801 - INFO - +---- START SUITE: Testsuites.001.001-01.001-01-01.Exercise-04-001-01-01 [ ]
 ==============================================================================
-20230118 14:34:11.052 - INFO - +----- START TEST: Test Case exercise-04-001-01-01 [ ]
+20230227 15:09:56.803 - INFO - +----- START TEST: Test Case exercise-04-001-01-01 [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:11.053 - INFO - +------ START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
-20230118 14:34:11.053 - INFO - teststring : I am the 'variant2' configuration of exercise 04
-20230118 14:34:11.057 - INFO - +------ END KEYWORD: BuiltIn.Log (0)
+20230227 15:09:56.808 - INFO - +------ START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:09:56.808 - INFO - teststring : I am the 'variant2' configuration of exercise 04
+20230227 15:09:56.809 - INFO - +------ END KEYWORD: BuiltIn.Log (0)
 ------------------------------------------------------------------------------
-20230118 14:34:11.058 - INFO - +----- END TEST: Test Case exercise-04-001-01-01 (5)
+20230227 15:09:56.810 - INFO - +----- END TEST: Test Case exercise-04-001-01-01 (6)
 ------------------------------------------------------------------------------
-20230118 14:34:11.061 - INFO - +---- END SUITE: Testsuites.001.001-01.001-01-01.Exercise-04-001-01-01 (9)
+20230227 15:09:56.813 - INFO - +---- END SUITE: Testsuites.001.001-01.001-01-01.Exercise-04-001-01-01 (10)
 ==============================================================================
-20230118 14:34:11.063 - INFO - +--- END SUITE: Testsuites.001.001-01.001-01-01 (15)
+20230227 15:09:56.814 - INFO - +--- END SUITE: Testsuites.001.001-01.001-01-01 (16)
 ==============================================================================
-20230118 14:34:11.065 - INFO - +--- START SUITE: Testsuites.001.001-01.Exercise-04-001-01 [ ]
+20230227 15:09:56.816 - INFO - +--- START SUITE: Testsuites.001.001-01.Exercise-04-001-01 [ ]
 ==============================================================================
-20230118 14:34:11.065 - INFO - +---- START TEST: Test Case exercise-04-001-01 [ ]
+20230227 15:09:56.817 - INFO - +---- START TEST: Test Case exercise-04-001-01 [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:11.068 - INFO - +----- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
-20230118 14:34:11.068 - INFO - teststring : I am the 'variant2' configuration of exercise 04
-20230118 14:34:11.072 - INFO - +----- END KEYWORD: BuiltIn.Log (0)
+20230227 15:09:56.818 - INFO - +----- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:09:56.818 - INFO - teststring : I am the 'variant2' configuration of exercise 04
+20230227 15:09:56.824 - INFO - +----- END KEYWORD: BuiltIn.Log (2)
 ------------------------------------------------------------------------------
-20230118 14:34:11.073 - INFO - +---- END TEST: Test Case exercise-04-001-01 (7)
+20230227 15:09:56.825 - INFO - +---- END TEST: Test Case exercise-04-001-01 (7)
 ------------------------------------------------------------------------------
-20230118 14:34:11.075 - INFO - +--- END SUITE: Testsuites.001.001-01.Exercise-04-001-01 (10)
+20230227 15:09:56.828 - INFO - +--- END SUITE: Testsuites.001.001-01.Exercise-04-001-01 (11)
 ==============================================================================
-20230118 14:34:11.077 - INFO - +-- END SUITE: Testsuites.001.001-01 (37)
+20230227 15:09:56.829 - INFO - +-- END SUITE: Testsuites.001.001-01 (35)
 ==============================================================================
-20230118 14:34:11.078 - INFO - +-- START SUITE: Testsuites.001.Exercise-04-001 [ ]
+20230227 15:09:56.831 - INFO - +-- START SUITE: Testsuites.001.Exercise-04-001 [ ]
 ==============================================================================
-20230118 14:34:11.079 - INFO - +--- START TEST: Test Case exercise-04-001 [ ]
+20230227 15:09:56.832 - INFO - +--- START TEST: Test Case exercise-04-001 [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:11.080 - INFO - +---- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
-20230118 14:34:11.080 - INFO - teststring : I am the 'variant2' configuration of exercise 04
-20230118 14:34:11.081 - INFO - +---- END KEYWORD: BuiltIn.Log (0)
+20230227 15:09:56.832 - INFO - +---- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:09:56.833 - INFO - teststring : I am the 'variant2' configuration of exercise 04
+20230227 15:09:56.838 - INFO - +---- END KEYWORD: BuiltIn.Log (2)
 ------------------------------------------------------------------------------
-20230118 14:34:11.086 - INFO - +--- END TEST: Test Case exercise-04-001 (2)
+20230227 15:09:56.840 - INFO - +--- END TEST: Test Case exercise-04-001 (7)
 ------------------------------------------------------------------------------
-20230118 14:34:11.089 - INFO - +-- END SUITE: Testsuites.001.Exercise-04-001 (9)
+20230227 15:09:56.842 - INFO - +-- END SUITE: Testsuites.001.Exercise-04-001 (11)
 ==============================================================================
-20230118 14:34:11.091 - INFO - +- END SUITE: Testsuites.001 (54)
+20230227 15:09:56.844 - INFO - +- END SUITE: Testsuites.001 (52)
 ==============================================================================
-20230118 14:34:11.092 - INFO - +- START SUITE: Testsuites.002 [ ]
+20230227 15:09:56.846 - INFO - +- START SUITE: Testsuites.002 [ ]
 ==============================================================================
-20230118 14:34:11.095 - INFO - +-- START SUITE: Testsuites.002.Exercise-04-002 [ ]
+20230227 15:09:56.850 - INFO - +-- START SUITE: Testsuites.002.Exercise-04-002 [ ]
 ==============================================================================
-20230118 14:34:11.096 - INFO - +--- START TEST: Test Case exercise-04-002 [ ]
+20230227 15:09:56.858 - INFO - +--- START TEST: Test Case exercise-04-002 [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:11.096 - INFO - +---- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
-20230118 14:34:11.096 - INFO - teststring : I am the 'variant2' configuration of exercise 04
-20230118 14:34:11.100 - INFO - +---- END KEYWORD: BuiltIn.Log (0)
+20230227 15:09:56.858 - INFO - +---- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:09:56.858 - INFO - teststring : I am the 'variant2' configuration of exercise 04
+20230227 15:09:56.859 - INFO - +---- END KEYWORD: BuiltIn.Log (0)
 ------------------------------------------------------------------------------
-20230118 14:34:11.107 - INFO - +--- END TEST: Test Case exercise-04-002 (6)
+20230227 15:09:56.860 - INFO - +--- END TEST: Test Case exercise-04-002 (1)
 ------------------------------------------------------------------------------
-20230118 14:34:11.109 - INFO - +-- END SUITE: Testsuites.002.Exercise-04-002 (14)
+20230227 15:09:56.861 - INFO - +-- END SUITE: Testsuites.002.Exercise-04-002 (12)
 ==============================================================================
-20230118 14:34:11.111 - INFO - +- END SUITE: Testsuites.002 (18)
+20230227 15:09:56.865 - INFO - +- END SUITE: Testsuites.002 (18)
 ==============================================================================
-20230118 14:34:11.113 - INFO - +- START SUITE: Testsuites.Exercise-04 [ ]
+20230227 15:09:56.867 - INFO - +- START SUITE: Testsuites.Exercise-04 [ ]
 ==============================================================================
-20230118 14:34:11.115 - INFO - +-- START TEST: Test Case exercise-04 [ ]
+20230227 15:09:56.870 - INFO - +-- START TEST: Test Case exercise-04 [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:11.118 - INFO - +--- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
-20230118 14:34:11.119 - INFO - teststring : I am the 'variant2' configuration of exercise 04
-20230118 14:34:11.119 - INFO - +--- END KEYWORD: BuiltIn.Log (1)
+20230227 15:09:56.870 - INFO - +--- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:09:56.870 - INFO - teststring : I am the 'variant2' configuration of exercise 04
+20230227 15:09:56.871 - INFO - +--- END KEYWORD: BuiltIn.Log (1)
 ------------------------------------------------------------------------------
-20230118 14:34:11.121 - INFO - +-- END TEST: Test Case exercise-04 (5)
+20230227 15:09:56.872 - INFO - +-- END TEST: Test Case exercise-04 (1)
 ------------------------------------------------------------------------------
-20230118 14:34:11.123 - INFO - +- END SUITE: Testsuites.Exercise-04 (10)
+20230227 15:09:56.874 - INFO - +- END SUITE: Testsuites.Exercise-04 (8)
 ==============================================================================
-20230118 14:34:11.125 - INFO - + END SUITE: Testsuites (213)
+20230227 15:09:56.887 - INFO - + END SUITE: Testsuites (227)
 ==============================================================================

--- a/test/tutorial-test/referencelogfiles/testsuites-E05-01/exercise-05.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E05-01/exercise-05.log
@@ -1,37 +1,38 @@
 ==============================================================================
-20230118 14:34:11.566 - INFO - + START SUITE: Exercise-05 [ ]
+20230227 15:09:57.380 - INFO - + START SUITE: Exercise-05 [ ]
 ==============================================================================
-20230118 14:34:11.573 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-05_variants.json ]
-20230118 14:34:11.595 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
-20230118 14:34:11.595 - INFO - Set suite metadata 'version_sw' to value ''.
-20230118 14:34:11.595 - INFO - Set suite metadata 'version_hw' to value ''.
-20230118 14:34:11.595 - INFO - Set suite metadata 'version_test' to value ''.
-20230118 14:34:11.595 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
-20230118 14:34:11.597 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
-20230118 14:34:11.597 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
-20230118 14:34:11.597 - INFO - Set suite metadata 'version' to value '0.6.0'.
-20230118 14:34:11.597 - INFO - ${teststring_common} = I am the common teststring valid for all variants
-20230118 14:34:11.598 - INFO - ${teststring} = I am the 'default' variant configuration of exercise 05
-20230118 14:34:11.599 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
-20230118 14:34:11.599 - INFO - Running with configuration level 2
-20230118 14:34:11.599 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-05\config\exercise-05_config_default.json'
-20230118 14:34:11.599 - INFO - Suite Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-05\
-20230118 14:34:11.599 - INFO - CfgFile Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-05\config\exercise-05_config_default.json
-20230118 14:34:11.599 - INFO - Suite Count: 1
-20230118 14:34:11.599 - INFO - Total testcases in TestSuite Exercise-05 is: 1
-20230118 14:34:11.599 - INFO - +- END SETUP: tm.Testsuite Setup (26)
+20230227 15:09:57.384 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-05_variants.json ]
+20230227 15:09:57.411 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
+20230227 15:09:57.411 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
+20230227 15:09:57.413 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
+20230227 15:09:57.413 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
+20230227 15:09:57.413 - INFO - Set suite metadata 'version' to value '0.6.0'.
+20230227 15:09:57.413 - INFO - Set suite metadata 'version_sw' to value ''.
+20230227 15:09:57.413 - INFO - Set suite metadata 'version_hw' to value ''.
+20230227 15:09:57.413 - INFO - Set suite metadata 'version_test' to value ''.
+20230227 15:09:57.414 - INFO - ${teststring_common} = I am the common teststring valid for all variants
+20230227 15:09:57.414 - INFO - ${teststring} = I am the 'default' variant configuration of exercise 05
+20230227 15:09:57.415 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
+20230227 15:09:57.415 - INFO - Running with configuration level 2
+20230227 15:09:57.415 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-05\config\exercise-05_config_default.json'
+20230227 15:09:57.415 - INFO - Robot Framework AIO version check passed!
+20230227 15:09:57.415 - INFO - Suite Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-05\'
+20230227 15:09:57.415 - INFO - CfgFile Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-05\config\exercise-05_config_default.json'
+20230227 15:09:57.415 - INFO - Number of test suites: 1
+20230227 15:09:57.415 - INFO - Total number of testcases: 1
+20230227 15:09:57.415 - INFO - +- END SETUP: tm.Testsuite Setup (31)
 ------------------------------------------------------------------------------
-20230118 14:34:11.599 - INFO - +- START TEST: Test Case exercise-05 [ ]
+20230227 15:09:57.416 - INFO - +- START TEST: Test Case exercise-05 [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:11.600 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_common : ${teststring_common} | console=yes ]
-20230118 14:34:11.600 - INFO - teststring_common : I am the common teststring valid for all variants
-20230118 14:34:11.601 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
+20230227 15:09:57.416 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_common : ${teststring_common} | console=yes ]
+20230227 15:09:57.417 - INFO - teststring_common : I am the common teststring valid for all variants
+20230227 15:09:57.418 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-20230118 14:34:11.601 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
-20230118 14:34:11.602 - INFO - teststring : I am the 'default' variant configuration of exercise 05
-20230118 14:34:11.606 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
+20230227 15:09:57.418 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:09:57.418 - INFO - teststring : I am the 'default' variant configuration of exercise 05
+20230227 15:09:57.419 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ------------------------------------------------------------------------------
-20230118 14:34:11.608 - INFO - +- END TEST: Test Case exercise-05 (7)
+20230227 15:09:57.420 - INFO - +- END TEST: Test Case exercise-05 (4)
 ------------------------------------------------------------------------------
-20230118 14:34:11.610 - INFO - + END SUITE: Exercise-05 (136)
+20230227 15:09:57.423 - INFO - + END SUITE: Exercise-05 (152)
 ==============================================================================

--- a/test/tutorial-test/referencelogfiles/testsuites-E05-02/exercise-05.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E05-02/exercise-05.log
@@ -1,37 +1,38 @@
 ==============================================================================
-20230118 14:34:12.022 - INFO - + START SUITE: Exercise-05 [ ]
+20230227 15:09:57.890 - INFO - + START SUITE: Exercise-05 [ ]
 ==============================================================================
-20230118 14:34:12.026 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-05_variants.json ]
-20230118 14:34:12.048 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
-20230118 14:34:12.048 - INFO - Set suite metadata 'version_sw' to value ''.
-20230118 14:34:12.048 - INFO - Set suite metadata 'version_hw' to value ''.
-20230118 14:34:12.048 - INFO - Set suite metadata 'version_test' to value ''.
-20230118 14:34:12.048 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
-20230118 14:34:12.051 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
-20230118 14:34:12.051 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
-20230118 14:34:12.051 - INFO - Set suite metadata 'version' to value '0.6.0'.
-20230118 14:34:12.052 - INFO - ${teststring_common} = I am the common teststring valid for all variants
-20230118 14:34:12.052 - INFO - ${teststring} = I am the 'variant1' configuration of exercise 05
-20230118 14:34:12.053 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
-20230118 14:34:12.053 - INFO - Running with configuration level 2
-20230118 14:34:12.053 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-05\config\exercise-05_config_variant1.json'
-20230118 14:34:12.053 - INFO - Suite Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-05\
-20230118 14:34:12.053 - INFO - CfgFile Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-05\config\exercise-05_config_variant1.json
-20230118 14:34:12.053 - INFO - Suite Count: 1
-20230118 14:34:12.053 - INFO - Total testcases in TestSuite Exercise-05 is: 1
-20230118 14:34:12.053 - INFO - +- END SETUP: tm.Testsuite Setup (27)
+20230227 15:09:57.894 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-05_variants.json ]
+20230227 15:09:57.923 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
+20230227 15:09:57.923 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
+20230227 15:09:57.925 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
+20230227 15:09:57.925 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
+20230227 15:09:57.925 - INFO - Set suite metadata 'version' to value '0.6.0'.
+20230227 15:09:57.925 - INFO - Set suite metadata 'version_sw' to value ''.
+20230227 15:09:57.925 - INFO - Set suite metadata 'version_hw' to value ''.
+20230227 15:09:57.925 - INFO - Set suite metadata 'version_test' to value ''.
+20230227 15:09:57.926 - INFO - ${teststring_common} = I am the common teststring valid for all variants
+20230227 15:09:57.926 - INFO - ${teststring} = I am the 'variant1' configuration of exercise 05
+20230227 15:09:57.927 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
+20230227 15:09:57.927 - INFO - Running with configuration level 2
+20230227 15:09:57.927 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-05\config\exercise-05_config_variant1.json'
+20230227 15:09:57.927 - INFO - Robot Framework AIO version check passed!
+20230227 15:09:57.927 - INFO - Suite Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-05\'
+20230227 15:09:57.927 - INFO - CfgFile Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-05\config\exercise-05_config_variant1.json'
+20230227 15:09:57.927 - INFO - Number of test suites: 1
+20230227 15:09:57.927 - INFO - Total number of testcases: 1
+20230227 15:09:57.927 - INFO - +- END SETUP: tm.Testsuite Setup (33)
 ------------------------------------------------------------------------------
-20230118 14:34:12.054 - INFO - +- START TEST: Test Case exercise-05 [ ]
+20230227 15:09:57.928 - INFO - +- START TEST: Test Case exercise-05 [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:12.054 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_common : ${teststring_common} | console=yes ]
-20230118 14:34:12.055 - INFO - teststring_common : I am the common teststring valid for all variants
-20230118 14:34:12.056 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
+20230227 15:09:57.929 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_common : ${teststring_common} | console=yes ]
+20230227 15:09:57.929 - INFO - teststring_common : I am the common teststring valid for all variants
+20230227 15:09:57.930 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-20230118 14:34:12.056 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
-20230118 14:34:12.056 - INFO - teststring : I am the 'variant1' configuration of exercise 05
-20230118 14:34:12.059 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
+20230227 15:09:57.930 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:09:57.930 - INFO - teststring : I am the 'variant1' configuration of exercise 05
+20230227 15:09:57.934 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ------------------------------------------------------------------------------
-20230118 14:34:12.061 - INFO - +- END TEST: Test Case exercise-05 (6)
+20230227 15:09:57.935 - INFO - +- END TEST: Test Case exercise-05 (7)
 ------------------------------------------------------------------------------
-20230118 14:34:12.062 - INFO - + END SUITE: Exercise-05 (133)
+20230227 15:09:57.937 - INFO - + END SUITE: Exercise-05 (150)
 ==============================================================================

--- a/test/tutorial-test/referencelogfiles/testsuites-E06-01/exercise-06.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E06-01/exercise-06.log
@@ -1,42 +1,43 @@
 ==============================================================================
-20230118 14:34:12.486 - INFO - + START SUITE: Exercise-06 [ ]
+20230227 15:09:58.417 - INFO - + START SUITE: Exercise-06 [ ]
 ==============================================================================
-20230118 14:34:12.489 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-06_variants.json ]
-20230118 14:34:12.510 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
-20230118 14:34:12.510 - INFO - Set suite metadata 'version_sw' to value ''.
-20230118 14:34:12.511 - INFO - Set suite metadata 'version_hw' to value ''.
-20230118 14:34:12.511 - INFO - Set suite metadata 'version_test' to value ''.
-20230118 14:34:12.511 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
-20230118 14:34:12.512 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
-20230118 14:34:12.513 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
-20230118 14:34:12.513 - INFO - Set suite metadata 'version' to value '0.6.0'.
-20230118 14:34:12.513 - INFO - ${teststring_common} = I am the common teststring valid for all variants and all test benches
-20230118 14:34:12.514 - INFO - ${teststring_bench} = I am the teststring containing the default value for all test benches
-20230118 14:34:12.514 - INFO - ${teststring_variant} = I am the 'default' variant configuration of exercise 06
-20230118 14:34:12.515 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
-20230118 14:34:12.515 - INFO - Running with configuration level 2
-20230118 14:34:12.515 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_default.json'
-20230118 14:34:12.515 - INFO - Suite Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-06\
-20230118 14:34:12.515 - INFO - CfgFile Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_default.json
-20230118 14:34:12.515 - INFO - Suite Count: 1
-20230118 14:34:12.515 - INFO - Total testcases in TestSuite Exercise-06 is: 1
-20230118 14:34:12.515 - INFO - +- END SETUP: tm.Testsuite Setup (26)
+20230227 15:09:58.428 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-06_variants.json ]
+20230227 15:09:58.461 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
+20230227 15:09:58.461 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
+20230227 15:09:58.463 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
+20230227 15:09:58.463 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
+20230227 15:09:58.463 - INFO - Set suite metadata 'version' to value '0.6.0'.
+20230227 15:09:58.463 - INFO - Set suite metadata 'version_sw' to value ''.
+20230227 15:09:58.463 - INFO - Set suite metadata 'version_hw' to value ''.
+20230227 15:09:58.463 - INFO - Set suite metadata 'version_test' to value ''.
+20230227 15:09:58.464 - INFO - ${teststring_common} = I am the common teststring valid for all variants and all test benches
+20230227 15:09:58.464 - INFO - ${teststring_bench} = I am the teststring containing the default value for all test benches
+20230227 15:09:58.465 - INFO - ${teststring_variant} = I am the 'default' variant configuration of exercise 06
+20230227 15:09:58.465 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
+20230227 15:09:58.465 - INFO - Running with configuration level 2
+20230227 15:09:58.465 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_default.json'
+20230227 15:09:58.465 - INFO - Robot Framework AIO version check passed!
+20230227 15:09:58.466 - INFO - Suite Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\'
+20230227 15:09:58.466 - INFO - CfgFile Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_default.json'
+20230227 15:09:58.466 - INFO - Number of test suites: 1
+20230227 15:09:58.466 - INFO - Total number of testcases: 1
+20230227 15:09:58.466 - INFO - +- END SETUP: tm.Testsuite Setup (38)
 ------------------------------------------------------------------------------
-20230118 14:34:12.516 - INFO - +- START TEST: Test Case exercise-06 [ ]
+20230227 15:09:58.466 - INFO - +- START TEST: Test Case exercise-06 [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:12.517 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_common : ${teststring_common} | console=yes ]
-20230118 14:34:12.517 - INFO - teststring_common : I am the common teststring valid for all variants and all test benches
-20230118 14:34:12.518 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
+20230227 15:09:58.467 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_common : ${teststring_common} | console=yes ]
+20230227 15:09:58.467 - INFO - teststring_common : I am the common teststring valid for all variants and all test benches
+20230227 15:09:58.469 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-20230118 14:34:12.518 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_variant : ${teststring_variant} | console=yes ]
-20230118 14:34:12.518 - INFO - teststring_variant : I am the 'default' variant configuration of exercise 06
-20230118 14:34:12.519 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
+20230227 15:09:58.469 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_variant : ${teststring_variant} | console=yes ]
+20230227 15:09:58.469 - INFO - teststring_variant : I am the 'default' variant configuration of exercise 06
+20230227 15:09:58.470 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-20230118 14:34:12.519 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_bench : ${teststring_bench} | console=yes ]
-20230118 14:34:12.519 - INFO - teststring_bench : I am the teststring containing the default value for all test benches
-20230118 14:34:12.520 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
+20230227 15:09:58.470 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_bench : ${teststring_bench} | console=yes ]
+20230227 15:09:58.470 - INFO - teststring_bench : I am the teststring containing the default value for all test benches
+20230227 15:09:58.473 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ------------------------------------------------------------------------------
-20230118 14:34:12.521 - INFO - +- END TEST: Test Case exercise-06 (4)
+20230227 15:09:58.474 - INFO - +- END TEST: Test Case exercise-06 (7)
 ------------------------------------------------------------------------------
-20230118 14:34:12.523 - INFO - + END SUITE: Exercise-06 (131)
+20230227 15:09:58.483 - INFO - + END SUITE: Exercise-06 (160)
 ==============================================================================

--- a/test/tutorial-test/referencelogfiles/testsuites-E06-02/exercise-06.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E06-02/exercise-06.log
@@ -1,42 +1,43 @@
 ==============================================================================
-20230118 14:34:12.944 - INFO - + START SUITE: Exercise-06 [ ]
+20230227 15:09:58.967 - INFO - + START SUITE: Exercise-06 [ ]
 ==============================================================================
-20230118 14:34:12.951 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-06_variants.json ]
-20230118 14:34:12.973 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
-20230118 14:34:12.973 - INFO - Set suite metadata 'version_sw' to value ''.
-20230118 14:34:12.973 - INFO - Set suite metadata 'version_hw' to value ''.
-20230118 14:34:12.973 - INFO - Set suite metadata 'version_test' to value ''.
-20230118 14:34:12.973 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
-20230118 14:34:12.975 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
-20230118 14:34:12.975 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
-20230118 14:34:12.975 - INFO - Set suite metadata 'version' to value '0.6.0'.
-20230118 14:34:12.976 - INFO - ${teststring_common} = I am the common teststring valid for all variants and all test benches
-20230118 14:34:12.976 - INFO - ${teststring_bench} = I am the teststring containing the default value for all test benches
-20230118 14:34:12.977 - INFO - ${teststring_variant} = I am the 'variant1' configuration of exercise 06
-20230118 14:34:12.977 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
-20230118 14:34:12.977 - INFO - Running with configuration level 2
-20230118 14:34:12.977 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_variant1.json'
-20230118 14:34:12.978 - INFO - Suite Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-06\
-20230118 14:34:12.978 - INFO - CfgFile Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_variant1.json
-20230118 14:34:12.978 - INFO - Suite Count: 1
-20230118 14:34:12.978 - INFO - Total testcases in TestSuite Exercise-06 is: 1
-20230118 14:34:12.978 - INFO - +- END SETUP: tm.Testsuite Setup (27)
+20230227 15:09:58.979 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-06_variants.json ]
+20230227 15:09:59.013 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
+20230227 15:09:59.013 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
+20230227 15:09:59.015 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
+20230227 15:09:59.015 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
+20230227 15:09:59.015 - INFO - Set suite metadata 'version' to value '0.6.0'.
+20230227 15:09:59.015 - INFO - Set suite metadata 'version_sw' to value ''.
+20230227 15:09:59.015 - INFO - Set suite metadata 'version_hw' to value ''.
+20230227 15:09:59.015 - INFO - Set suite metadata 'version_test' to value ''.
+20230227 15:09:59.016 - INFO - ${teststring_common} = I am the common teststring valid for all variants and all test benches
+20230227 15:09:59.016 - INFO - ${teststring_bench} = I am the teststring containing the default value for all test benches
+20230227 15:09:59.017 - INFO - ${teststring_variant} = I am the 'variant1' configuration of exercise 06
+20230227 15:09:59.018 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
+20230227 15:09:59.018 - INFO - Running with configuration level 2
+20230227 15:09:59.018 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_variant1.json'
+20230227 15:09:59.018 - INFO - Robot Framework AIO version check passed!
+20230227 15:09:59.018 - INFO - Suite Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\'
+20230227 15:09:59.018 - INFO - CfgFile Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_variant1.json'
+20230227 15:09:59.018 - INFO - Number of test suites: 1
+20230227 15:09:59.018 - INFO - Total number of testcases: 1
+20230227 15:09:59.018 - INFO - +- END SETUP: tm.Testsuite Setup (39)
 ------------------------------------------------------------------------------
-20230118 14:34:12.978 - INFO - +- START TEST: Test Case exercise-06 [ ]
+20230227 15:09:59.019 - INFO - +- START TEST: Test Case exercise-06 [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:12.979 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_common : ${teststring_common} | console=yes ]
-20230118 14:34:12.979 - INFO - teststring_common : I am the common teststring valid for all variants and all test benches
-20230118 14:34:12.980 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
+20230227 15:09:59.020 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_common : ${teststring_common} | console=yes ]
+20230227 15:09:59.020 - INFO - teststring_common : I am the common teststring valid for all variants and all test benches
+20230227 15:09:59.021 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-20230118 14:34:12.980 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_variant : ${teststring_variant} | console=yes ]
-20230118 14:34:12.981 - INFO - teststring_variant : I am the 'variant1' configuration of exercise 06
-20230118 14:34:12.981 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
+20230227 15:09:59.021 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_variant : ${teststring_variant} | console=yes ]
+20230227 15:09:59.021 - INFO - teststring_variant : I am the 'variant1' configuration of exercise 06
+20230227 15:09:59.022 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-20230118 14:34:12.982 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_bench : ${teststring_bench} | console=yes ]
-20230118 14:34:12.982 - INFO - teststring_bench : I am the teststring containing the default value for all test benches
-20230118 14:34:12.983 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
+20230227 15:09:59.022 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_bench : ${teststring_bench} | console=yes ]
+20230227 15:09:59.022 - INFO - teststring_bench : I am the teststring containing the default value for all test benches
+20230227 15:09:59.023 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ------------------------------------------------------------------------------
-20230118 14:34:12.984 - INFO - +- END TEST: Test Case exercise-06 (5)
+20230227 15:09:59.024 - INFO - +- END TEST: Test Case exercise-06 (5)
 ------------------------------------------------------------------------------
-20230118 14:34:12.991 - INFO - + END SUITE: Exercise-06 (134)
+20230227 15:09:59.027 - INFO - + END SUITE: Exercise-06 (174)
 ==============================================================================

--- a/test/tutorial-test/referencelogfiles/testsuites-E06-03/exercise-06.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E06-03/exercise-06.log
@@ -1,43 +1,45 @@
 ==============================================================================
-20230118 14:34:13.432 - INFO - + START SUITE: Exercise-06 [ ]
+20230227 15:09:59.516 - INFO - + START SUITE: Exercise-06 [ ]
 ==============================================================================
-20230118 14:34:13.440 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-06_variants.json ]
-20230118 14:34:13.463 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
-20230118 14:34:13.463 - INFO - Set suite metadata 'version_sw' to value ''.
-20230118 14:34:13.463 - INFO - Set suite metadata 'version_hw' to value ''.
-20230118 14:34:13.463 - INFO - Set suite metadata 'version_test' to value ''.
-20230118 14:34:13.463 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
-20230118 14:34:13.465 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
-20230118 14:34:13.465 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
-20230118 14:34:13.465 - INFO - Set suite metadata 'version' to value '0.6.0'.
-20230118 14:34:13.466 - INFO - ${teststring_common} = I am the common teststring valid for all variants and all test benches
-20230118 14:34:13.466 - INFO - ${teststring_bench} = I am the 'bench1' configuration of exercise 06
-20230118 14:34:13.467 - INFO - ${teststring_variant} = I am the 'default' variant configuration of exercise 06
-20230118 14:34:13.467 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}, "...
-20230118 14:34:13.467 - INFO - Running with configuration level 2
-20230118 14:34:13.467 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_default.json'
-20230118 14:34:13.467 - INFO - Suite Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-06\
-20230118 14:34:13.468 - INFO - CfgFile Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_default.json
-20230118 14:34:13.468 - INFO - Local config file: C:\RobotTest\tutorial\900_building_testsuites\exercise-06\localconfig\exercise-06_localconfig_bench1.json
-20230118 14:34:13.468 - INFO - Suite Count: 1
-20230118 14:34:13.468 - INFO - Total testcases in TestSuite Exercise-06 is: 1
-20230118 14:34:13.468 - INFO - +- END SETUP: tm.Testsuite Setup (28)
+20230227 15:09:59.524 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-06_variants.json ]
+20230227 15:09:59.554 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
+20230227 15:09:59.554 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
+20230227 15:09:59.556 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
+20230227 15:09:59.556 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
+20230227 15:09:59.556 - INFO - Set suite metadata 'version' to value '0.6.0'.
+20230227 15:09:59.556 - INFO - Set suite metadata 'version_sw' to value ''.
+20230227 15:09:59.556 - INFO - Set suite metadata 'version_hw' to value ''.
+20230227 15:09:59.556 - INFO - Set suite metadata 'version_test' to value ''.
+20230227 15:09:59.557 - INFO - ${teststring_common} = I am the common teststring valid for all variants and all test benches
+20230227 15:09:59.558 - INFO - ${teststring_bench} = I am the 'bench1' configuration of exercise 06
+20230227 15:09:59.558 - INFO - ${teststring_variant} = I am the 'default' variant configuration of exercise 06
+20230227 15:09:59.559 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
+20230227 15:09:59.559 - INFO - The parameter 'params['global']['teststring_bench']' is updated
+20230227 15:09:59.559 - INFO - Running with configuration level 2
+20230227 15:09:59.559 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_default.json'
+20230227 15:09:59.559 - INFO - Robot Framework AIO version check passed!
+20230227 15:09:59.559 - INFO - Suite Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\'
+20230227 15:09:59.559 - INFO - CfgFile Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_default.json'
+20230227 15:09:59.559 - INFO - Local config file: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\localconfig\exercise-06_localconfig_bench1.json'
+20230227 15:09:59.559 - INFO - Number of test suites: 1
+20230227 15:09:59.559 - INFO - Total number of testcases: 1
+20230227 15:09:59.560 - INFO - +- END SETUP: tm.Testsuite Setup (36)
 ------------------------------------------------------------------------------
-20230118 14:34:13.468 - INFO - +- START TEST: Test Case exercise-06 [ ]
+20230227 15:09:59.560 - INFO - +- START TEST: Test Case exercise-06 [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:13.469 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_common : ${teststring_common} | console=yes ]
-20230118 14:34:13.469 - INFO - teststring_common : I am the common teststring valid for all variants and all test benches
-20230118 14:34:13.475 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
+20230227 15:09:59.561 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_common : ${teststring_common} | console=yes ]
+20230227 15:09:59.561 - INFO - teststring_common : I am the common teststring valid for all variants and all test benches
+20230227 15:09:59.562 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-20230118 14:34:13.475 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_variant : ${teststring_variant} | console=yes ]
-20230118 14:34:13.475 - INFO - teststring_variant : I am the 'default' variant configuration of exercise 06
-20230118 14:34:13.476 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
+20230227 15:09:59.562 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_variant : ${teststring_variant} | console=yes ]
+20230227 15:09:59.562 - INFO - teststring_variant : I am the 'default' variant configuration of exercise 06
+20230227 15:09:59.563 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-20230118 14:34:13.476 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_bench : ${teststring_bench} | console=yes ]
-20230118 14:34:13.477 - INFO - teststring_bench : I am the 'bench1' configuration of exercise 06
-20230118 14:34:13.480 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
+20230227 15:09:59.563 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_bench : ${teststring_bench} | console=yes ]
+20230227 15:09:59.563 - INFO - teststring_bench : I am the 'bench1' configuration of exercise 06
+20230227 15:09:59.567 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ------------------------------------------------------------------------------
-20230118 14:34:13.481 - INFO - +- END TEST: Test Case exercise-06 (12)
+20230227 15:09:59.568 - INFO - +- END TEST: Test Case exercise-06 (7)
 ------------------------------------------------------------------------------
-20230118 14:34:13.484 - INFO - + END SUITE: Exercise-06 (157)
+20230227 15:09:59.574 - INFO - + END SUITE: Exercise-06 (164)
 ==============================================================================

--- a/test/tutorial-test/referencelogfiles/testsuites-E06-04/exercise-06.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E06-04/exercise-06.log
@@ -1,43 +1,45 @@
 ==============================================================================
-20230118 14:34:13.900 - INFO - + START SUITE: Exercise-06 [ ]
+20230227 15:10:00.088 - INFO - + START SUITE: Exercise-06 [ ]
 ==============================================================================
-20230118 14:34:13.908 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-06_variants.json ]
-20230118 14:34:13.931 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
-20230118 14:34:13.932 - INFO - Set suite metadata 'version_sw' to value ''.
-20230118 14:34:13.932 - INFO - Set suite metadata 'version_hw' to value ''.
-20230118 14:34:13.932 - INFO - Set suite metadata 'version_test' to value ''.
-20230118 14:34:13.932 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
-20230118 14:34:13.933 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
-20230118 14:34:13.934 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
-20230118 14:34:13.934 - INFO - Set suite metadata 'version' to value '0.6.0'.
-20230118 14:34:13.934 - INFO - ${teststring_common} = I am the common teststring valid for all variants and all test benches
-20230118 14:34:13.935 - INFO - ${teststring_bench} = I am the 'bench1' configuration of exercise 06
-20230118 14:34:13.935 - INFO - ${teststring_variant} = I am the 'variant2' configuration of exercise 06
-20230118 14:34:13.936 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}, "...
-20230118 14:34:13.936 - INFO - Running with configuration level 2
-20230118 14:34:13.936 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_variant2.json'
-20230118 14:34:13.936 - INFO - Suite Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-06\
-20230118 14:34:13.936 - INFO - CfgFile Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_variant2.json
-20230118 14:34:13.936 - INFO - Local config file: C:\RobotTest\tutorial\900_building_testsuites\exercise-06\localconfig\exercise-06_localconfig_bench1.json
-20230118 14:34:13.936 - INFO - Suite Count: 1
-20230118 14:34:13.937 - INFO - Total testcases in TestSuite Exercise-06 is: 1
-20230118 14:34:13.937 - INFO - +- END SETUP: tm.Testsuite Setup (29)
+20230227 15:10:00.096 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-06_variants.json ]
+20230227 15:10:00.126 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
+20230227 15:10:00.126 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
+20230227 15:10:00.128 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
+20230227 15:10:00.128 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
+20230227 15:10:00.128 - INFO - Set suite metadata 'version' to value '0.6.0'.
+20230227 15:10:00.128 - INFO - Set suite metadata 'version_sw' to value ''.
+20230227 15:10:00.128 - INFO - Set suite metadata 'version_hw' to value ''.
+20230227 15:10:00.128 - INFO - Set suite metadata 'version_test' to value ''.
+20230227 15:10:00.129 - INFO - ${teststring_common} = I am the common teststring valid for all variants and all test benches
+20230227 15:10:00.129 - INFO - ${teststring_bench} = I am the 'bench1' configuration of exercise 06
+20230227 15:10:00.130 - INFO - ${teststring_variant} = I am the 'variant2' configuration of exercise 06
+20230227 15:10:00.130 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
+20230227 15:10:00.130 - INFO - The parameter 'params['global']['teststring_bench']' is updated
+20230227 15:10:00.131 - INFO - Running with configuration level 2
+20230227 15:10:00.131 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_variant2.json'
+20230227 15:10:00.131 - INFO - Robot Framework AIO version check passed!
+20230227 15:10:00.131 - INFO - Suite Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\'
+20230227 15:10:00.131 - INFO - CfgFile Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_variant2.json'
+20230227 15:10:00.131 - INFO - Local config file: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\localconfig\exercise-06_localconfig_bench1.json'
+20230227 15:10:00.131 - INFO - Number of test suites: 1
+20230227 15:10:00.131 - INFO - Total number of testcases: 1
+20230227 15:10:00.131 - INFO - +- END SETUP: tm.Testsuite Setup (35)
 ------------------------------------------------------------------------------
-20230118 14:34:13.937 - INFO - +- START TEST: Test Case exercise-06 [ ]
+20230227 15:10:00.131 - INFO - +- START TEST: Test Case exercise-06 [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:13.938 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_common : ${teststring_common} | console=yes ]
-20230118 14:34:13.938 - INFO - teststring_common : I am the common teststring valid for all variants and all test benches
-20230118 14:34:13.945 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
+20230227 15:10:00.132 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_common : ${teststring_common} | console=yes ]
+20230227 15:10:00.133 - INFO - teststring_common : I am the common teststring valid for all variants and all test benches
+20230227 15:10:00.133 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-20230118 14:34:13.945 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_variant : ${teststring_variant} | console=yes ]
-20230118 14:34:13.945 - INFO - teststring_variant : I am the 'variant2' configuration of exercise 06
-20230118 14:34:13.946 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
+20230227 15:10:00.134 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_variant : ${teststring_variant} | console=yes ]
+20230227 15:10:00.134 - INFO - teststring_variant : I am the 'variant2' configuration of exercise 06
+20230227 15:10:00.139 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-20230118 14:34:13.946 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_bench : ${teststring_bench} | console=yes ]
-20230118 14:34:13.946 - INFO - teststring_bench : I am the 'bench1' configuration of exercise 06
-20230118 14:34:13.947 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
+20230227 15:10:00.139 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_bench : ${teststring_bench} | console=yes ]
+20230227 15:10:00.139 - INFO - teststring_bench : I am the 'bench1' configuration of exercise 06
+20230227 15:10:00.140 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
 ------------------------------------------------------------------------------
-20230118 14:34:13.948 - INFO - +- END TEST: Test Case exercise-06 (10)
+20230227 15:10:00.141 - INFO - +- END TEST: Test Case exercise-06 (9)
 ------------------------------------------------------------------------------
-20230118 14:34:13.950 - INFO - + END SUITE: Exercise-06 (142)
+20230227 15:10:00.144 - INFO - + END SUITE: Exercise-06 (163)
 ==============================================================================

--- a/test/tutorial-test/referencelogfiles/testsuites-E06-05/exercise-06.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E06-05/exercise-06.log
@@ -1,43 +1,45 @@
 ==============================================================================
-20230118 14:34:14.373 - INFO - + START SUITE: Exercise-06 [ ]
+20230227 15:10:00.624 - INFO - + START SUITE: Exercise-06 [ ]
 ==============================================================================
-20230118 14:34:14.378 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-06_variants.json ]
-20230118 14:34:14.400 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
-20230118 14:34:14.400 - INFO - Set suite metadata 'version_sw' to value ''.
-20230118 14:34:14.400 - INFO - Set suite metadata 'version_hw' to value ''.
-20230118 14:34:14.400 - INFO - Set suite metadata 'version_test' to value ''.
-20230118 14:34:14.400 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
-20230118 14:34:14.402 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
-20230118 14:34:14.402 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
-20230118 14:34:14.402 - INFO - Set suite metadata 'version' to value '0.6.0'.
-20230118 14:34:14.403 - INFO - ${teststring_common} = I am the common teststring valid for all variants and all test benches
-20230118 14:34:14.403 - INFO - ${teststring_bench} = I am the 'bench1' configuration of exercise 06
-20230118 14:34:14.404 - INFO - ${teststring_variant} = I am the 'variant2' configuration of exercise 06
-20230118 14:34:14.404 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}, "...
-20230118 14:34:14.404 - INFO - Running with configuration level 2
-20230118 14:34:14.404 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_variant2.json'
-20230118 14:34:14.404 - INFO - Suite Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-06\
-20230118 14:34:14.404 - INFO - CfgFile Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_variant2.json
-20230118 14:34:14.405 - INFO - Local config file: C:\RobotTest\tutorial\900_building_testsuites\exercise-06\localconfig\exercise-06_localconfig_bench1.json
-20230118 14:34:14.405 - INFO - Suite Count: 1
-20230118 14:34:14.405 - INFO - Total testcases in TestSuite Exercise-06 is: 1
-20230118 14:34:14.405 - INFO - +- END SETUP: tm.Testsuite Setup (27)
+20230227 15:10:00.635 - INFO - +- START SETUP: tm.Testsuite Setup [ ./config/exercise-06_variants.json ]
+20230227 15:10:00.665 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
+20230227 15:10:00.665 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
+20230227 15:10:00.667 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
+20230227 15:10:00.667 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
+20230227 15:10:00.667 - INFO - Set suite metadata 'version' to value '0.6.0'.
+20230227 15:10:00.667 - INFO - Set suite metadata 'version_sw' to value ''.
+20230227 15:10:00.667 - INFO - Set suite metadata 'version_hw' to value ''.
+20230227 15:10:00.667 - INFO - Set suite metadata 'version_test' to value ''.
+20230227 15:10:00.668 - INFO - ${teststring_common} = I am the common teststring valid for all variants and all test benches
+20230227 15:10:00.669 - INFO - ${teststring_bench} = I am the 'bench1' configuration of exercise 06
+20230227 15:10:00.669 - INFO - ${teststring_variant} = I am the 'variant2' configuration of exercise 06
+20230227 15:10:00.670 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
+20230227 15:10:00.670 - INFO - The parameter 'params['global']['teststring_bench']' is updated
+20230227 15:10:00.670 - INFO - Running with configuration level 2
+20230227 15:10:00.670 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_variant2.json'
+20230227 15:10:00.670 - INFO - Robot Framework AIO version check passed!
+20230227 15:10:00.670 - INFO - Suite Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\'
+20230227 15:10:00.670 - INFO - CfgFile Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\config\exercise-06_config_variant2.json'
+20230227 15:10:00.670 - INFO - Local config file: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-06\localconfig\exercise-06_localconfig_bench1.json'
+20230227 15:10:00.670 - INFO - Number of test suites: 1
+20230227 15:10:00.670 - INFO - Total number of testcases: 1
+20230227 15:10:00.670 - INFO - +- END SETUP: tm.Testsuite Setup (35)
 ------------------------------------------------------------------------------
-20230118 14:34:14.405 - INFO - +- START TEST: Test Case exercise-06 [ ]
+20230227 15:10:00.671 - INFO - +- START TEST: Test Case exercise-06 [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:14.406 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_common : ${teststring_common} | console=yes ]
-20230118 14:34:14.406 - INFO - teststring_common : I am the common teststring valid for all variants and all test benches
-20230118 14:34:14.413 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
+20230227 15:10:00.672 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_common : ${teststring_common} | console=yes ]
+20230227 15:10:00.672 - INFO - teststring_common : I am the common teststring valid for all variants and all test benches
+20230227 15:10:00.673 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-20230118 14:34:14.413 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_variant : ${teststring_variant} | console=yes ]
-20230118 14:34:14.413 - INFO - teststring_variant : I am the 'variant2' configuration of exercise 06
-20230118 14:34:14.414 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
+20230227 15:10:00.673 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_variant : ${teststring_variant} | console=yes ]
+20230227 15:10:00.673 - INFO - teststring_variant : I am the 'variant2' configuration of exercise 06
+20230227 15:10:00.674 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-20230118 14:34:14.414 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_bench : ${teststring_bench} | console=yes ]
-20230118 14:34:14.415 - INFO - teststring_bench : I am the 'bench1' configuration of exercise 06
-20230118 14:34:14.418 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
+20230227 15:10:00.674 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring_bench : ${teststring_bench} | console=yes ]
+20230227 15:10:00.674 - INFO - teststring_bench : I am the 'bench1' configuration of exercise 06
+20230227 15:10:00.675 - INFO - +-- END KEYWORD: BuiltIn.Log (0)
 ------------------------------------------------------------------------------
-20230118 14:34:14.419 - INFO - +- END TEST: Test Case exercise-06 (13)
+20230227 15:10:00.677 - INFO - +- END TEST: Test Case exercise-06 (4)
 ------------------------------------------------------------------------------
-20230118 14:34:14.426 - INFO - + END SUITE: Exercise-06 (138)
+20230227 15:10:00.678 - INFO - + END SUITE: Exercise-06 (163)
 ==============================================================================

--- a/test/tutorial-test/referencelogfiles/testsuites-E07-01/exercise-07.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E07-01/exercise-07.log
@@ -1,24 +1,23 @@
 ==============================================================================
-20230118 14:34:14.836 - INFO - + START SUITE: Exercise-07 [ ]
+20230227 15:10:01.172 - INFO - + START SUITE: Exercise-07 [ ]
 ==============================================================================
-20230118 14:34:14.867 - INFO - +- START SETUP: tm.Testsuite Setup [ ]
-20230118 14:34:14.867 - WARN - Running with configuration level 1! 
-Selected configuration file 'C:\RobotTest\tutorial\900_building_testsuites\exercise-07\config\exercise-07_config_variant1.json'
-20230118 14:34:14.869 - INFO - Running with configuration level 1
-20230118 14:34:14.869 - INFO - Suite Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-07\
-20230118 14:34:14.869 - INFO - CfgFile Path: C:\RobotTest\tutorial\900_building_testsuites\exercise-07\config\exercise-07_config_variant1.json
-20230118 14:34:14.869 - INFO - Local config file: C:\RobotTest\tutorial\900_building_testsuites\exercise-07\localconfig\exercise-07_localconfig_bench1.json
-20230118 14:34:14.869 - INFO - Suite Count: 1
-20230118 14:34:14.869 - INFO - Total testcases in TestSuite Exercise-07 is: 1
-20230118 14:34:14.869 - INFO - +- END SETUP: tm.Testsuite Setup (2)
+20230227 15:10:01.208 - INFO - +- START SETUP: tm.Testsuite Setup [ ]
+20230227 15:10:01.208 - INFO - Running with configuration level 1
+20230227 15:10:01.208 - INFO - Robot Framework AIO version check passed!
+20230227 15:10:01.208 - INFO - Suite Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-07\'
+20230227 15:10:01.208 - INFO - CfgFile Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-07\config\exercise-07_config_variant1.json'
+20230227 15:10:01.208 - INFO - Local config file: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-07\localconfig\exercise-07_localconfig_bench1.json'
+20230227 15:10:01.208 - INFO - Number of test suites: 1
+20230227 15:10:01.208 - INFO - Total number of testcases: 1
+20230227 15:10:01.208 - INFO - +- END SETUP: tm.Testsuite Setup (0)
 ------------------------------------------------------------------------------
-20230118 14:34:14.869 - INFO - +- START TEST: Test Case exercise-07 [ ]
+20230227 15:10:01.209 - INFO - +- START TEST: Test Case exercise-07 [ ]
 ------------------------------------------------------------------------------
-20230118 14:34:14.870 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
-20230118 14:34:14.871 - INFO - teststring : command line test string
-20230118 14:34:14.874 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
+20230227 15:10:01.209 - INFO - +-- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:10:01.210 - INFO - teststring : command line test string
+20230227 15:10:01.211 - INFO - +-- END KEYWORD: BuiltIn.Log (1)
 ------------------------------------------------------------------------------
-20230118 14:34:14.874 - INFO - +- END TEST: Test Case exercise-07 (5)
+20230227 15:10:01.215 - INFO - +- END TEST: Test Case exercise-07 (2)
 ------------------------------------------------------------------------------
-20230118 14:34:14.886 - INFO - + END SUITE: Exercise-07 (135)
+20230227 15:10:01.217 - INFO - + END SUITE: Exercise-07 (147)
 ==============================================================================


### PR DESCRIPTION
This branch do:
- ROBFW-366: replace robotframework-excellibrary-xwfintech(https://pypi.org/project/robotframework-excellibrary-xwfintech/) by robotframework-excellib](https://pypi.org/project/robotframework-excellib/
- ROBFW-347: support workspace for vscodium. Warning when change RobotTest folder location while install
- Change pypandoc package to pybandoc_binary package to fix test errors.