### PR TITLE
Ntd1hc/feat/introduction of fully automated continous test

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -146,7 +146,9 @@ jobs:
         name: linux-package
 
     - name: Install on Linux
-      run: sudo apt-get install ./*.deb
+      run: |
+        sudo apt-get update
+        sudo apt-get install ./*.deb --fix-missing
 
     - name: Run tests on Linux
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ logfiles/
 ExecutionLogFile.log
 test/**/*.html
 test/**/*.xml
-test/**/*.log
+test/tutorial-test/tutoriallogfiles/**/*.log

--- a/config/build/dpkg_build/postinst.sh
+++ b/config/build/dpkg_build/postinst.sh
@@ -7,7 +7,10 @@
 echo "Creating/Updating RobotFramework AIO runtime environment"
 echo "----------------------------------------"
 
-CURRENT_USER=$(whoami)
+CURRENT_USER=${SUDO_USER}
+if [ -z ${CURRENT_USER} ]; then
+   CURRENT_USER=$(whoami)
+fi
 HOME=/home/${CURRENT_USER}
 DLTCONNECTOR_PATH="/opt/rfwaio/python39/install/lib/python3.9/site-packages/QConnectionDLTLibrary/tools/DLTConnector/linux/"
 DLTCONNECTOR_NAME="DLTConnector_v1.3.9.deb"

--- a/config/build/dpkg_build/postinst.sh
+++ b/config/build/dpkg_build/postinst.sh
@@ -7,7 +7,7 @@
 echo "Creating/Updating RobotFramework AIO runtime environment"
 echo "----------------------------------------"
 
-CURRENT_USER=${SUDO_USER}
+CURRENT_USER=$(whoami)
 HOME=/home/${CURRENT_USER}
 DLTCONNECTOR_PATH="/opt/rfwaio/python39/install/lib/python3.9/site-packages/QConnectionDLTLibrary/tools/DLTConnector/linux/"
 DLTCONNECTOR_NAME="DLTConnector_v1.3.9.deb"
@@ -16,7 +16,7 @@ DLTCONNECTOR_NAME="DLTConnector_v1.3.9.deb"
 #in osd5 group name is "domain users". Therefore
 #look if a group wi th the user name exists, if not
 #then we assume that we are on OSD5
-sGROUP=${SUDO_USER}
+sGROUP=$(id -G)
 if ! getent group "${sGROUP}" | grep "${sGROUP}" ; then
    sGROUP='domain users'
    echo -e "Assuming OSD5 and using group 'domain users' as user group for private files"

--- a/test/tutorial-test/referencelogfiles/testsuites-E04-01/exercise-04.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E04-01/exercise-04.log
@@ -31,7 +31,7 @@
 ==============================================================================
 20230227 15:09:56.803 - INFO - +----- START TEST: Test Case exercise-04-001-01-01 [ ]
 ------------------------------------------------------------------------------
-20230227 15:09:56.808 - INFO - +------ START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:09:56.808 - INFO - +------ START KEYWORD: BuiltIn.Log [ teststring : ${teststring} (exercise-04-001-01-01.robot) | console=yes ]
 20230227 15:09:56.808 - INFO - teststring : I am the 'variant2' configuration of exercise 04
 20230227 15:09:56.809 - INFO - +------ END KEYWORD: BuiltIn.Log (0)
 ------------------------------------------------------------------------------
@@ -45,7 +45,7 @@
 ==============================================================================
 20230227 15:09:56.817 - INFO - +---- START TEST: Test Case exercise-04-001-01 [ ]
 ------------------------------------------------------------------------------
-20230227 15:09:56.818 - INFO - +----- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:09:56.818 - INFO - +----- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} (exercise-04-001-01.robot) | console=yes ]
 20230227 15:09:56.818 - INFO - teststring : I am the 'variant2' configuration of exercise 04
 20230227 15:09:56.824 - INFO - +----- END KEYWORD: BuiltIn.Log (2)
 ------------------------------------------------------------------------------
@@ -59,7 +59,7 @@
 ==============================================================================
 20230227 15:09:56.832 - INFO - +--- START TEST: Test Case exercise-04-001 [ ]
 ------------------------------------------------------------------------------
-20230227 15:09:56.832 - INFO - +---- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:09:56.832 - INFO - +---- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} (exercise-04-001.robot) | console=yes ]
 20230227 15:09:56.833 - INFO - teststring : I am the 'variant2' configuration of exercise 04
 20230227 15:09:56.838 - INFO - +---- END KEYWORD: BuiltIn.Log (2)
 ------------------------------------------------------------------------------
@@ -75,7 +75,7 @@
 ==============================================================================
 20230227 15:09:56.858 - INFO - +--- START TEST: Test Case exercise-04-002 [ ]
 ------------------------------------------------------------------------------
-20230227 15:09:56.858 - INFO - +---- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230227 15:09:56.858 - INFO - +---- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} (exercise-04-002.robot) | console=yes ]
 20230227 15:09:56.858 - INFO - teststring : I am the 'variant2' configuration of exercise 04
 20230227 15:09:56.859 - INFO - +---- END KEYWORD: BuiltIn.Log (0)
 ------------------------------------------------------------------------------

--- a/test/tutorial-test/referencelogfiles/testsuites-E04-01/exercise-04.log
+++ b/test/tutorial-test/referencelogfiles/testsuites-E04-01/exercise-04.log
@@ -1,101 +1,101 @@
 ==============================================================================
-20230227 15:09:56.751 - INFO - + START SUITE: Testsuites [ ]
+20230306 02:42:03.273 - INFO - + START SUITE: Testsuites [ ]
 ==============================================================================
-20230227 15:09:56.755 - INFO - +- START SETUP: tm.Testsuite Setup [ ../config/exercise-04_variants.json ]
-20230227 15:09:56.786 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
-20230227 15:09:56.786 - INFO - Set suite metadata 'machine' to value 'HI7-C-0005Y'.
-20230227 15:09:56.787 - INFO - Set suite metadata 'tester' to value 'Queckenstedt Holger (XC-CT/ECA3)'.
-20230227 15:09:56.788 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.16 on win32)'.
-20230227 15:09:56.788 - INFO - Set suite metadata 'version' to value '0.6.0'.
-20230227 15:09:56.788 - INFO - Set suite metadata 'version_sw' to value ''.
-20230227 15:09:56.788 - INFO - Set suite metadata 'version_hw' to value ''.
-20230227 15:09:56.788 - INFO - Set suite metadata 'version_test' to value ''.
-20230227 15:09:56.788 - INFO - ${teststring} = I am the 'variant2' configuration of exercise 04
-20230227 15:09:56.789 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
-20230227 15:09:56.789 - INFO - Running with configuration level 2
-20230227 15:09:56.789 - INFO - Parameters loaded from 'C:\RobotTest\tutorial\900_building_testsuites\exercise-04\config\exercise-04_config_variant2.json'
-20230227 15:09:56.789 - INFO - Robot Framework AIO version check passed!
-20230227 15:09:56.789 - INFO - Suite Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-04\testsuites'
-20230227 15:09:56.789 - INFO - CfgFile Path: 'C:\RobotTest\tutorial\900_building_testsuites\exercise-04\config\exercise-04_config_variant2.json'
-20230227 15:09:56.789 - INFO - Number of test suites: 1
-20230227 15:09:56.790 - INFO - Total number of testcases: 5
-20230227 15:09:56.790 - INFO - +- END SETUP: tm.Testsuite Setup (35)
+20230306 02:42:03.287 - INFO - +- START SETUP: tm.Testsuite Setup [ ../config/exercise-04_variants.json ]
+20230306 02:42:03.317 - INFO - Set suite metadata 'project' to value 'RobotFramework Testsuites'.
+20230306 02:42:03.317 - INFO - Set suite metadata 'machine' to value 'HC1-V-0002Y'.
+20230306 02:42:03.318 - INFO - Set suite metadata 'tester' to value 'gitlab-runner'.
+20230306 02:42:03.318 - INFO - Set suite metadata 'testtool' to value 'Robot Framework 4.1.3 (Python 3.9.2 on linux)'.
+20230306 02:42:03.318 - INFO - Set suite metadata 'version' to value '0.6.0'.
+20230306 02:42:03.318 - INFO - Set suite metadata 'version_sw' to value ''.
+20230306 02:42:03.319 - INFO - Set suite metadata 'version_hw' to value ''.
+20230306 02:42:03.319 - INFO - Set suite metadata 'version_test' to value ''.
+20230306 02:42:03.321 - INFO - ${teststring} = I am the 'variant2' configuration of exercise 04
+20230306 02:42:03.323 - INFO - ${CONFIG} = {'WelcomeString': 'Hello... Robot Framework is running now!', 'Maximum_version': '1.0.0', 'Minimum_version': '0.6.0', 'Project': 'RobotFramework Testsuites', 'TargetName': 'Device_01', 'params': {}}
+20230306 02:42:03.323 - INFO - Running with configuration level 2
+20230306 02:42:03.323 - INFO - Parameters loaded from '/home/gitlab-runner/RobotTest/tutorial/900_building_testsuites/exercise-04/config/exercise-04_config_variant2.json'
+20230306 02:42:03.324 - INFO - Robot Framework AIO version check passed!
+20230306 02:42:03.324 - INFO - Suite Path: '/home/gitlab-runner/RobotTest/tutorial/900_building_testsuites/exercise-04/testsuites'
+20230306 02:42:03.324 - INFO - CfgFile Path: '/home/gitlab-runner/RobotTest/tutorial/900_building_testsuites/exercise-04/config/exercise-04_config_variant2.json'
+20230306 02:42:03.324 - INFO - Number of test suites: 1
+20230306 02:42:03.324 - INFO - Total number of testcases: 5
+20230306 02:42:03.325 - INFO - +- END SETUP: tm.Testsuite Setup (38)
 ==============================================================================
-20230227 15:09:56.791 - INFO - +- START SUITE: Testsuites.001 [ ]
+20230306 02:42:03.330 - INFO - +- START SUITE: Testsuites.001 [ ]
 ==============================================================================
-20230227 15:09:56.795 - INFO - +-- START SUITE: Testsuites.001.001-01 [ ]
+20230306 02:42:03.340 - INFO - +-- START SUITE: Testsuites.001.001-01 [ ]
 ==============================================================================
-20230227 15:09:56.799 - INFO - +--- START SUITE: Testsuites.001.001-01.001-01-01 [ ]
+20230306 02:42:03.349 - INFO - +--- START SUITE: Testsuites.001.001-01.001-01-01 [ ]
 ==============================================================================
-20230227 15:09:56.801 - INFO - +---- START SUITE: Testsuites.001.001-01.001-01-01.Exercise-04-001-01-01 [ ]
+20230306 02:42:03.357 - INFO - +---- START SUITE: Testsuites.001.001-01.001-01-01.Exercise-04-001-01-01 [ ]
 ==============================================================================
-20230227 15:09:56.803 - INFO - +----- START TEST: Test Case exercise-04-001-01-01 [ ]
+20230306 02:42:03.362 - INFO - +----- START TEST: Test Case exercise-04-001-01-01 [ ]
 ------------------------------------------------------------------------------
-20230227 15:09:56.808 - INFO - +------ START KEYWORD: BuiltIn.Log [ teststring : ${teststring} (exercise-04-001-01-01.robot) | console=yes ]
-20230227 15:09:56.808 - INFO - teststring : I am the 'variant2' configuration of exercise 04
-20230227 15:09:56.809 - INFO - +------ END KEYWORD: BuiltIn.Log (0)
+20230306 02:42:03.363 - INFO - +------ START KEYWORD: BuiltIn.Log [ teststring : ${teststring} (exercise-04-001-01-01.robot) | console=yes ]
+20230306 02:42:03.364 - INFO - teststring : I am the 'variant2' configuration of exercise 04 (exercise-04-001-01-01.robot)
+20230306 02:42:03.367 - INFO - +------ END KEYWORD: BuiltIn.Log (3)
 ------------------------------------------------------------------------------
-20230227 15:09:56.810 - INFO - +----- END TEST: Test Case exercise-04-001-01-01 (6)
+20230306 02:42:03.372 - INFO - +----- END TEST: Test Case exercise-04-001-01-01 (7)
 ------------------------------------------------------------------------------
-20230227 15:09:56.813 - INFO - +---- END SUITE: Testsuites.001.001-01.001-01-01.Exercise-04-001-01-01 (10)
+20230306 02:42:03.381 - INFO - +---- END SUITE: Testsuites.001.001-01.001-01-01.Exercise-04-001-01-01 (22)
 ==============================================================================
-20230227 15:09:56.814 - INFO - +--- END SUITE: Testsuites.001.001-01.001-01-01 (16)
+20230306 02:42:03.384 - INFO - +--- END SUITE: Testsuites.001.001-01.001-01-01 (37)
 ==============================================================================
-20230227 15:09:56.816 - INFO - +--- START SUITE: Testsuites.001.001-01.Exercise-04-001-01 [ ]
+20230306 02:42:03.389 - INFO - +--- START SUITE: Testsuites.001.001-01.Exercise-04-001-01 [ ]
 ==============================================================================
-20230227 15:09:56.817 - INFO - +---- START TEST: Test Case exercise-04-001-01 [ ]
+20230306 02:42:03.392 - INFO - +---- START TEST: Test Case exercise-04-001-01 [ ]
 ------------------------------------------------------------------------------
-20230227 15:09:56.818 - INFO - +----- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} (exercise-04-001-01.robot) | console=yes ]
-20230227 15:09:56.818 - INFO - teststring : I am the 'variant2' configuration of exercise 04
-20230227 15:09:56.824 - INFO - +----- END KEYWORD: BuiltIn.Log (2)
+20230306 02:42:03.393 - INFO - +----- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} (exercise-04-001-01.robot) | console=yes ]
+20230306 02:42:03.394 - INFO - teststring : I am the 'variant2' configuration of exercise 04 (exercise-04-001-01.robot)
+20230306 02:42:03.395 - INFO - +----- END KEYWORD: BuiltIn.Log (1)
 ------------------------------------------------------------------------------
-20230227 15:09:56.825 - INFO - +---- END TEST: Test Case exercise-04-001-01 (7)
+20230306 02:42:03.395 - INFO - +---- END TEST: Test Case exercise-04-001-01 (4)
 ------------------------------------------------------------------------------
-20230227 15:09:56.828 - INFO - +--- END SUITE: Testsuites.001.001-01.Exercise-04-001-01 (11)
+20230306 02:42:03.397 - INFO - +--- END SUITE: Testsuites.001.001-01.Exercise-04-001-01 (12)
 ==============================================================================
-20230227 15:09:56.829 - INFO - +-- END SUITE: Testsuites.001.001-01 (35)
+20230306 02:42:03.398 - INFO - +-- END SUITE: Testsuites.001.001-01 (63)
 ==============================================================================
-20230227 15:09:56.831 - INFO - +-- START SUITE: Testsuites.001.Exercise-04-001 [ ]
+20230306 02:42:03.403 - INFO - +-- START SUITE: Testsuites.001.Exercise-04-001 [ ]
 ==============================================================================
-20230227 15:09:56.832 - INFO - +--- START TEST: Test Case exercise-04-001 [ ]
+20230306 02:42:03.403 - INFO - +--- START TEST: Test Case exercise-04-001 [ ]
 ------------------------------------------------------------------------------
-20230227 15:09:56.832 - INFO - +---- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} (exercise-04-001.robot) | console=yes ]
-20230227 15:09:56.833 - INFO - teststring : I am the 'variant2' configuration of exercise 04
-20230227 15:09:56.838 - INFO - +---- END KEYWORD: BuiltIn.Log (2)
+20230306 02:42:03.404 - INFO - +---- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} (exercise-04-001.robot) | console=yes ]
+20230306 02:42:03.404 - INFO - teststring : I am the 'variant2' configuration of exercise 04 (exercise-04-001.robot)
+20230306 02:42:03.405 - INFO - +---- END KEYWORD: BuiltIn.Log (0)
 ------------------------------------------------------------------------------
-20230227 15:09:56.840 - INFO - +--- END TEST: Test Case exercise-04-001 (7)
+20230306 02:42:03.405 - INFO - +--- END TEST: Test Case exercise-04-001 (2)
 ------------------------------------------------------------------------------
-20230227 15:09:56.842 - INFO - +-- END SUITE: Testsuites.001.Exercise-04-001 (11)
+20230306 02:42:03.406 - INFO - +-- END SUITE: Testsuites.001.Exercise-04-001 (6)
 ==============================================================================
-20230227 15:09:56.844 - INFO - +- END SUITE: Testsuites.001 (52)
+20230306 02:42:03.407 - INFO - +- END SUITE: Testsuites.001 (81)
 ==============================================================================
-20230227 15:09:56.846 - INFO - +- START SUITE: Testsuites.002 [ ]
+20230306 02:42:03.410 - INFO - +- START SUITE: Testsuites.002 [ ]
 ==============================================================================
-20230227 15:09:56.850 - INFO - +-- START SUITE: Testsuites.002.Exercise-04-002 [ ]
+20230306 02:42:03.412 - INFO - +-- START SUITE: Testsuites.002.Exercise-04-002 [ ]
 ==============================================================================
-20230227 15:09:56.858 - INFO - +--- START TEST: Test Case exercise-04-002 [ ]
+20230306 02:42:03.413 - INFO - +--- START TEST: Test Case exercise-04-002 [ ]
 ------------------------------------------------------------------------------
-20230227 15:09:56.858 - INFO - +---- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} (exercise-04-002.robot) | console=yes ]
-20230227 15:09:56.858 - INFO - teststring : I am the 'variant2' configuration of exercise 04
-20230227 15:09:56.859 - INFO - +---- END KEYWORD: BuiltIn.Log (0)
+20230306 02:42:03.414 - INFO - +---- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} (exercise-04-002.robot) | console=yes ]
+20230306 02:42:03.414 - INFO - teststring : I am the 'variant2' configuration of exercise 04 (exercise-04-002.robot)
+20230306 02:42:03.414 - INFO - +---- END KEYWORD: BuiltIn.Log (1)
 ------------------------------------------------------------------------------
-20230227 15:09:56.860 - INFO - +--- END TEST: Test Case exercise-04-002 (1)
+20230306 02:42:03.414 - INFO - +--- END TEST: Test Case exercise-04-002 (1)
 ------------------------------------------------------------------------------
-20230227 15:09:56.861 - INFO - +-- END SUITE: Testsuites.002.Exercise-04-002 (12)
+20230306 02:42:03.415 - INFO - +-- END SUITE: Testsuites.002.Exercise-04-002 (5)
 ==============================================================================
-20230227 15:09:56.865 - INFO - +- END SUITE: Testsuites.002 (18)
+20230306 02:42:03.416 - INFO - +- END SUITE: Testsuites.002 (9)
 ==============================================================================
-20230227 15:09:56.867 - INFO - +- START SUITE: Testsuites.Exercise-04 [ ]
+20230306 02:42:03.419 - INFO - +- START SUITE: Testsuites.Exercise-04 [ ]
 ==============================================================================
-20230227 15:09:56.870 - INFO - +-- START TEST: Test Case exercise-04 [ ]
+20230306 02:42:03.420 - INFO - +-- START TEST: Test Case exercise-04 [ ]
 ------------------------------------------------------------------------------
-20230227 15:09:56.870 - INFO - +--- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
-20230227 15:09:56.870 - INFO - teststring : I am the 'variant2' configuration of exercise 04
-20230227 15:09:56.871 - INFO - +--- END KEYWORD: BuiltIn.Log (1)
+20230306 02:42:03.420 - INFO - +--- START KEYWORD: BuiltIn.Log [ teststring : ${teststring} | console=yes ]
+20230306 02:42:03.421 - INFO - teststring : I am the 'variant2' configuration of exercise 04
+20230306 02:42:03.422 - INFO - +--- END KEYWORD: BuiltIn.Log (1)
 ------------------------------------------------------------------------------
-20230227 15:09:56.872 - INFO - +-- END TEST: Test Case exercise-04 (1)
+20230306 02:42:03.422 - INFO - +-- END TEST: Test Case exercise-04 (3)
 ------------------------------------------------------------------------------
-20230227 15:09:56.874 - INFO - +- END SUITE: Testsuites.Exercise-04 (8)
+20230306 02:42:03.423 - INFO - +- END SUITE: Testsuites.Exercise-04 (6)
 ==============================================================================
-20230227 15:09:56.887 - INFO - + END SUITE: Testsuites (227)
+20230306 02:42:03.425 - INFO - + END SUITE: Testsuites (355)
 ==============================================================================


### PR DESCRIPTION
Hi Thomas,

This PR contains below fixes and updates:
- Avoid issues when installing AIO on linux (Github runner and Apertis runner)
- Enhance the `clone_update_repo` to avoid clone issue on our self-host runners when default branch changed on remote.
- Adapt reference logfile for tutorial test `exercise-04`. The error is not displayed in build log but when I tried to run the tutorial-test.py manually, the below error came:
```
(1) Test log file      : C:/B/builds/arMTRgkB/0/ntd1hc/RobotFramework_AIO/test/tutorial-test/tutoriallogfiles/testsuites-E04-01/exercise-04.log
(2) Reference log file : C:/B/builds/arMTRgkB/0/ntd1hc/RobotFramework_AIO/test/tutorial-test/referencelogfiles/testsuites-E04-01/exercise-04.log
(3) Pattern file       : C:/B/builds/arMTRgkB/0/ntd1hc/RobotFramework_AIO/test/tutorial-test/config/tutorial-test_pattern.txt

Found deviating lines
(1) 'teststring : ${teststring} (exercise-04-001-01-01.robot) | console=yes ]'
(2) 'teststring : ${teststring} | console=yes ]'!

Usecase 'testsuites-E04-01' failed (failed up to now: 1) [Computation of folder containing several robot files]!
```

Thank you,
Ngoan