### PR TITLE
adapt HOME directory on linux when install AIO as root user

### DIFF
--- a/config/build/dpkg_build/postinst.sh
+++ b/config/build/dpkg_build/postinst.sh
@@ -11,7 +11,7 @@ CURRENT_USER=${SUDO_USER}
 if [ -z ${CURRENT_USER} ]; then
    CURRENT_USER=$(whoami)
 fi
-HOME=/home/${CURRENT_USER}
+# HOME=/home/${CURRENT_USER}
 DLTCONNECTOR_PATH="/opt/rfwaio/python39/install/lib/python3.9/site-packages/QConnectionDLTLibrary/tools/DLTConnector/linux/"
 DLTCONNECTOR_NAME="DLTConnector_v1.3.9.deb"
 


### PR DESCRIPTION
Hi Thomas,

This change fixes the error when testing on Apertis as root user.
The home folder is **/root** instead of **/home/root** that leads to incorrect env set for Robot, then aio-trigger failed with tutorial test due to incorrect path.

Thank you,
Ngoan