### PR TITLE
fix OSS linux test job due to missing tutorial test

### DIFF
--- a/config/build/dpkg_build/postinst.sh
+++ b/config/build/dpkg_build/postinst.sh
@@ -11,7 +11,11 @@ CURRENT_USER=${SUDO_USER}
 if [ -z ${CURRENT_USER} ]; then
    CURRENT_USER=$(whoami)
 fi
-# HOME=/home/${CURRENT_USER}
+# When executing as root user $HOME can be /root
+# Otherwises, /home/<user> should be used
+if [ ${CURRENT_USER} != 'root' ]; then
+   HOME=/home/${CURRENT_USER}
+fi
 DLTCONNECTOR_PATH="/opt/rfwaio/python39/install/lib/python3.9/site-packages/QConnectionDLTLibrary/tools/DLTConnector/linux/"
 DLTCONNECTOR_NAME="DLTConnector_v1.3.9.deb"
 


### PR DESCRIPTION
Hi Thomas,

My previous commit is still not strong enough to cover the OSS Linux job that lead to failed test job after merging.
https://github.com/test-fullautomation/RobotFramework_AIO/actions/runs/4364777813/jobs/7645938350
I have updated the $HOME setting to cover it. 

Thank you,
Ngoan