### PR TITLE
Added --junit-prefix to all PYTEST executions

### DIFF
--- a/test/aio-test-trigger/config/dbapp_config.json
+++ b/test/aio-test-trigger/config/dbapp_config.json
@@ -1,15 +1,15 @@
 {
    "components"  : {
-                     "Py Ext Coll."     : ["Comparison", "File", "Folder", "String", "Utils", "PythonExtensionsCollection"],
+                     "Py Ext Coll"      : "PythonExtensionsCollection",
                      "Gen Pkg Doc"      : "GenPackageDoc",
-                     "J Pre Pro"        : ["jsonpreprocessor", "JsonPreprocessor"],
+                     "J Pre Pro"        : "JsonPreprocessor",
                      "Micr Srv Base"    : "MicroserviceBase",
                      "Micr Srv Cle Swi" : "MicroserviceClewareSwitch",
                      "PyTest Log 2 DB"  : "PyTestLog2DB",
                      "Tut Test"         : "TutorialTest",
                      "RF Ext Coll"      : "robotframework-extensions-collection",
-                     "RF Log 2 DB"      : "robotframework-robotlog2db",
-                     "RF Log 2 RQM"     : "robotframework-robotlog2rqm",
+                     "RF Log 2 DB"      : "RobotLog2DB",
+                     "RF Log 2 RQM"     : "RobotLog2RQM",
                      "RF TSM"           : "robotframework-testsuitesmanagement",
                      "RF atest"         : "atest"
                    }

--- a/test/aio-test-trigger/config/dbapp_config.json
+++ b/test/aio-test-trigger/config/dbapp_config.json
@@ -1,15 +1,16 @@
 {
    "components"  : {
-                     "PyExColl"      : ["Comparison", "File", "Folder", "String", "Utils", "PythonExtensionsCollection"],
-                     "GenPkgDoc"     : "GenPackageDoc",
-                     "JPrePro"       : ["jsonpreprocessor", "JsonPreprocessor"],
-                     "MicrSrvBase"   : "MicroserviceBase",
-                     "MicrSrvCleSwi" : "MicroserviceClewareSwitch",
-                     "PyTstLog2DB"   : "PyTestLog2DB",
-                     "TutTest"       : "TutorialTest",
-                     "RoExtColl"     : "robotframework-extensions-collection",
-                     "RobLog2DB"     : "robotframework-robotlog2db",
-                     "RobLog2RQM"    : "robotframework-robotlog2rqm",
-                     "TeSuitMa"      : "robotframework-testsuitesmanagement"
+                     "Py Ext Coll."     : ["Comparison", "File", "Folder", "String", "Utils", "PythonExtensionsCollection"],
+                     "Gen Pkg Doc"      : "GenPackageDoc",
+                     "J Pre Pro"        : ["jsonpreprocessor", "JsonPreprocessor"],
+                     "Micr Srv Base"    : "MicroserviceBase",
+                     "Micr Srv Cle Swi" : "MicroserviceClewareSwitch",
+                     "PyTest Log 2 DB"  : "PyTestLog2DB",
+                     "Tut Test"         : "TutorialTest",
+                     "RF Ext Coll"      : "robotframework-extensions-collection",
+                     "RF Log 2 DB"      : "robotframework-robotlog2db",
+                     "RF Log 2 RQM"     : "robotframework-robotlog2rqm",
+                     "RF TSM"           : "robotframework-testsuitesmanagement",
+                     "RF atest"         : "atest"
                    }
 }

--- a/test/aio-test-trigger/config/testtrigger_config.json
+++ b/test/aio-test-trigger/config/testtrigger_config.json
@@ -2,7 +2,7 @@
 #
 # Test Trigger configuration file
 #
-# 01.03.2023
+# 08.03.2023
 #
 # **************************************************************************************************************
 # Format: extended json format with the possibility to comment out lines (by '#' at the beginning of the line).
@@ -124,6 +124,15 @@
                        "TESTEXECUTOR"      : "executerobottest.py",
                        "LOCALCOMMANDLINE"  : ["--exclude atestExcluded"],
                        "LOGFILE"           : "../../../../robotframework-testsuitesmanagement/atest/aiotestlogfiles/aiotestlogfile.xml"
+                    },
+                    {
+                       "COMPONENTROOTPATH" : "C:/RobotTest/projects/ROBFW_AIO/robotframework",
+                       "TESTFOLDER"        : "atest",
+                       "TESTTYPE"          : "ROBOT",
+                       "TESTEXECUTOR"      : "run.py",
+                       "LOCALCOMMANDLINE"  : ["${PYTHONINTERPRETER}", "-d \"./atest/aiotestlogfiles\"", "-b aiotestlogfile.log", "-o aiotestlogfile.xml", "\"./atest/robot\""],
+                       "LOGFILE"           : "../../../../robotframework/atest/aiotestlogfiles/aiotestlogfile.xml",
+                       "EXECUTION"         : "RAW"
                     }
                   ],
 

--- a/test/aio-test-trigger/config/testtrigger_config.json
+++ b/test/aio-test-trigger/config/testtrigger_config.json
@@ -2,7 +2,7 @@
 #
 # Test Trigger configuration file
 #
-# 08.03.2023
+# 09.03.2023
 #
 # **************************************************************************************************************
 # Format: extended json format with the possibility to comment out lines (by '#' at the beginning of the line).
@@ -130,7 +130,7 @@
                        "TESTFOLDER"        : "atest",
                        "TESTTYPE"          : "ROBOT",
                        "TESTEXECUTOR"      : "run.py",
-                       "LOCALCOMMANDLINE"  : ["${PYTHONINTERPRETER}", "-d \"./atest/aiotestlogfiles\"", "-b aiotestlogfile.log", "-o aiotestlogfile.xml", "\"./atest/robot\""],
+                       "LOCALCOMMANDLINE"  : ["${PYTHONINTERPRETER}", "-d \"./atest/aiotestlogfiles\"", "-b aiotestlogfile.log", "-o aiotestlogfile.xml", "--exclude manual", "\"./atest/robot\""],
                        "LOGFILE"           : "../../../../robotframework/atest/aiotestlogfiles/aiotestlogfile.xml",
                        "EXECUTION"         : "RAW"
                     }

--- a/test/aio-test-trigger/config/testtrigger_config_full.json
+++ b/test/aio-test-trigger/config/testtrigger_config_full.json
@@ -137,7 +137,7 @@
                        "LOGFILE"           : "../../../../robotframework-testsuitesmanagement/atest/aiotestlogfiles/aiotestlogfile.xml"
                     },
                     {
-                       "COMPONENTROOTPATH" : "C:/RobotTest/projects/ROBFW_AIO/robotframework",
+                       "COMPONENTROOTPATH" : "../../../../robotframework",
                        "TESTFOLDER"        : "atest",
                        "TESTTYPE"          : "ROBOT",
                        "TESTEXECUTOR"      : "run.py",

--- a/test/aio-test-trigger/config/testtrigger_config_full.json
+++ b/test/aio-test-trigger/config/testtrigger_config_full.json
@@ -2,7 +2,7 @@
 #
 # Test Trigger configuration file
 #
-# Standard version without robotframework/atest
+# Full version including robotframework/atest
 #
 # 09.03.2023
 #
@@ -135,6 +135,15 @@
                        "TESTEXECUTOR"      : "executerobottest.py",
                        "LOCALCOMMANDLINE"  : ["--exclude atestExcluded"],
                        "LOGFILE"           : "../../../../robotframework-testsuitesmanagement/atest/aiotestlogfiles/aiotestlogfile.xml"
+                    },
+                    {
+                       "COMPONENTROOTPATH" : "C:/RobotTest/projects/ROBFW_AIO/robotframework",
+                       "TESTFOLDER"        : "atest",
+                       "TESTTYPE"          : "ROBOT",
+                       "TESTEXECUTOR"      : "run.py",
+                       "LOCALCOMMANDLINE"  : ["${PYTHONINTERPRETER}", "-d \"./atest/aiotestlogfiles\"", "-b aiotestlogfile.log", "-o aiotestlogfile.xml", "--exclude manual", "\"./atest/robot\""],
+                       "LOGFILE"           : "../../../../robotframework/atest/aiotestlogfiles/aiotestlogfile.xml",
+                       "EXECUTION"         : "RAW"
                     }
                   ],
 

--- a/test/aio-test-trigger/libs/CTestTrigger.py
+++ b/test/aio-test-trigger/libs/CTestTrigger.py
@@ -150,44 +150,79 @@ class CTestTrigger():
          TESTEXECUTOR      = dictComponent['TESTEXECUTOR']
          LOCALCOMMANDLINE  = dictComponent['LOCALCOMMANDLINE']
          LOGFILE           = dictComponent['LOGFILE']
+         EXECUTION         = dictComponent['EXECUTION']
 
          # -- prepare the command line for the test execution
 
          listCmdLineParts = []
          listCmdLineParts.append(f"\"{PYTHON}\"")
          listCmdLineParts.append(f"\"{TESTEXECUTOR}\"")
-         listCmdLineParts.append("--logfile")
-         listCmdLineParts.append(f"\"{LOGFILE}\"")
 
-         if LOCALCOMMANDLINE is not None:
-            # recover the masking of nested quotes
-            LOCALCOMMANDLINE = LOCALCOMMANDLINE.replace("\"", r"\"")
-            LOCALCOMMANDLINE = LOCALCOMMANDLINE.replace("'", r"\"")
+         if EXECUTION is None:
 
-         if TESTTYPE == "ROBOT":
-            if ( (ROBOTCOMMANDLINE is not None) or (LOCALCOMMANDLINE is not None) ):
-               listCmdLineParts.append(f"--robotcommandline")
-               if ( (ROBOTCOMMANDLINE is not None) and (LOCALCOMMANDLINE is None) ):
-                  listCmdLineParts.append(f"\"{ROBOTCOMMANDLINE}\"")
-               elif ( (ROBOTCOMMANDLINE is None) and (LOCALCOMMANDLINE is not None) ):
-                  listCmdLineParts.append(f"\"{LOCALCOMMANDLINE}\"")
-               elif ( (ROBOTCOMMANDLINE is not None) and (LOCALCOMMANDLINE is not None) ):
-                  listCmdLineParts.append(f"\"{ROBOTCOMMANDLINE} {LOCALCOMMANDLINE}\"")
+            # -- execution of own test executors
 
-         if TESTTYPE == "PYTEST":
-            if ( (PYTESTCOMMANDLINE is not None) or (LOCALCOMMANDLINE is not None) ):
-               listCmdLineParts.append(f"--pytestcommandline")
-               if ( (PYTESTCOMMANDLINE is not None) and (LOCALCOMMANDLINE is None) ):
-                  listCmdLineParts.append(f"\"{PYTESTCOMMANDLINE}\"")
-               elif ( (PYTESTCOMMANDLINE is None) and (LOCALCOMMANDLINE is not None) ):
-                  listCmdLineParts.append(f"\"{LOCALCOMMANDLINE}\"")
-               elif ( (PYTESTCOMMANDLINE is not None) and (LOCALCOMMANDLINE is not None) ):
-                  listCmdLineParts.append(f"\"{PYTESTCOMMANDLINE} {LOCALCOMMANDLINE}\"")
+            listCmdLineParts.append("--logfile")
+            listCmdLineParts.append(f"\"{LOGFILE}\"")
+
+            if LOCALCOMMANDLINE is not None:
+               # recover the masking of nested quotes
+               LOCALCOMMANDLINE = LOCALCOMMANDLINE.replace("\"", r"\"")
+               LOCALCOMMANDLINE = LOCALCOMMANDLINE.replace("'", r"\"")
+
+            if TESTTYPE == "ROBOT":
+               if ( (ROBOTCOMMANDLINE is not None) or (LOCALCOMMANDLINE is not None) ):
+                  listCmdLineParts.append(f"--robotcommandline")
+                  if ( (ROBOTCOMMANDLINE is not None) and (LOCALCOMMANDLINE is None) ):
+                     listCmdLineParts.append(f"\"{ROBOTCOMMANDLINE}\"")
+                  elif ( (ROBOTCOMMANDLINE is None) and (LOCALCOMMANDLINE is not None) ):
+                     listCmdLineParts.append(f"\"{LOCALCOMMANDLINE}\"")
+                  elif ( (ROBOTCOMMANDLINE is not None) and (LOCALCOMMANDLINE is not None) ):
+                     listCmdLineParts.append(f"\"{ROBOTCOMMANDLINE} {LOCALCOMMANDLINE}\"")
+
+            if TESTTYPE == "PYTEST":
+               if ( (PYTESTCOMMANDLINE is not None) or (LOCALCOMMANDLINE is not None) ):
+                  listCmdLineParts.append(f"--pytestcommandline")
+                  if ( (PYTESTCOMMANDLINE is not None) and (LOCALCOMMANDLINE is None) ):
+                     listCmdLineParts.append(f"\"{PYTESTCOMMANDLINE}\"")
+                  elif ( (PYTESTCOMMANDLINE is None) and (LOCALCOMMANDLINE is not None) ):
+                     listCmdLineParts.append(f"\"{LOCALCOMMANDLINE}\"")
+                  elif ( (PYTESTCOMMANDLINE is not None) and (LOCALCOMMANDLINE is not None) ):
+                     listCmdLineParts.append(f"\"{PYTESTCOMMANDLINE} {LOCALCOMMANDLINE}\"")
+
+         else:
+
+            # -- execution of foreign test executors
+            #
+            # EXECUTION is not None, the value currently doesn't matter (but value "RAW" assumed; other values maybe later);
+            # nothing more to distinguish between here, therefore 'else' only.
+            #
+            # !!! ROBOTCOMMANDLINE and PYTESTCOMMANDLINE are not considered !!!
+            #
+            # LOCALCOMMANDLINE (if available) is passed unmodified to the TESTEXECUTOR (= without possible command line extensions like '--logfile')
+
+            if LOCALCOMMANDLINE is not None:
+               listCmdLineParts.append(f"{LOCALCOMMANDLINE}")
+
+         # eof else - if EXECUTION is None:
+
+         # currently hard coded handover here (and not taken out of the configuration file); let's see if this is future proof
+         # (and suitable for all kind of executions)
+         CWD = COMPONENTROOTPATH
 
          sCmdLine = " ".join(listCmdLineParts)
          del listCmdLineParts
 
-         self.__oExecutionLogFile.Write(sCmdLine)
+         # -- delete previous log file
+
+         oLogFile = CFile(LOGFILE)
+         bSuccess, sResult = oLogFile.Delete(bConfirmDelete=False)
+         del oLogFile
+         if bSuccess is not True:
+            sResult = CString.FormatResult(sMethod, bSuccess, sResult)
+            self.__oExecutionLogFile.Write(sResult)
+            printerror(sResult)
+            continue # for dictComponent in listofdictComponents:
 
          # -- execute the tests
 
@@ -196,19 +231,29 @@ class CTestTrigger():
          print(f"* ({nCntComponent}/{nNrOfComponents}) : '{TESTFOLDER}' ({TESTTYPE})")
          print()
 
-         print(f"Now executing command line:\n{sCmdLine}")
+         self.__oExecutionLogFile.Write(sCmdLine)
+
+         if EXECUTION is None:
+            print(f"Now executing command line:\n{sCmdLine}")
+         else:
+            print(f"Now executing '{EXECUTION}' command line:\n{sCmdLine}")
          print()
 
          listCmdLineParts = shlex.split(sCmdLine)
 
          nReturn = ERROR
+         sCurrentWorkingDirectory = os.getcwd()
          try:
+            if CWD is not None:
+               os.chdir(CWD)
             nReturn = subprocess.call(listCmdLineParts)
+            os.chdir(sCurrentWorkingDirectory)
             # Executor may return negative values; must be converted back to negative value after received here
             nReturn = ctypes.c_int32(nReturn).value
             print()
             print(f"[test trigger] : Subprocess {TESTTYPE} executor returned {nReturn}")
          except Exception as ex:
+            os.chdir(sCurrentWorkingDirectory)
             nReturn  = ERROR
             bSuccess = None
             sResult  = CString.FormatResult(sMethod, bSuccess, str(ex))
@@ -264,15 +309,15 @@ class CTestTrigger():
          sCmdLine = " ".join(listCmdLineParts)
          del listCmdLineParts
 
-         self.__oExecutionLogFile.Write(sCmdLine)
-
          # -- execute the database application
 
          print(COLBY + "Writing testresults to database")
          print()
          # sCmdLine contains database credentials, therefore is not printed
+         # self.__oExecutionLogFile.Write(sCmdLine)
          # print(f"Now executing command line:\n{sCmdLine}")
          # alternative:
+         self.__oExecutionLogFile.Write(f"Now executing: {DATABASEEXECUTOR}")
          print(f"Now executing: {DATABASEEXECUTOR}")
          print()
 

--- a/test/aio-test-trigger/version.py
+++ b/test/aio-test-trigger/version.py
@@ -19,6 +19,6 @@
 # Version and date of aio-test-trigger
 #
 NAME         = "RobotFramework AIO Test Trigger"
-VERSION      = "0.14.0"
-VERSION_DATE = "08.03.2023"
+VERSION      = "0.15.0"
+VERSION_DATE = "09.03.2023"
 

--- a/test/aio-test-trigger/version.py
+++ b/test/aio-test-trigger/version.py
@@ -19,6 +19,6 @@
 # Version and date of aio-test-trigger
 #
 NAME         = "RobotFramework AIO Test Trigger"
-VERSION      = "0.15.0"
+VERSION      = "0.16.0"
 VERSION_DATE = "09.03.2023"
 

--- a/test/aio-test-trigger/version.py
+++ b/test/aio-test-trigger/version.py
@@ -19,6 +19,6 @@
 # Version and date of aio-test-trigger
 #
 NAME         = "RobotFramework AIO Test Trigger"
-VERSION      = "0.13.0"
+VERSION      = "0.14.0"
 VERSION_DATE = "08.03.2023"
 


### PR DESCRIPTION
Added --junit-prefix to all PYTEST executions; adapted mapping table; further adaptions

Out of testtrigger_config.json I derived testtrigger_config_full.json.
The full version includes the robotframework/atest; the standard version does not include.
Reason: Save ~20min execution time for robotframework/atest (maybe not required in every case)

Took over the filter mechanism (not _Linux_/not _Windows_) from PYTEST TESTEXECUTOR executepytest.py.
This was necessary because of the Test Trigger now also uses the PYTEST LOCALCOMMANDLINE (--junit-prefix)
and therefore is now fully responsible for the TESTEXECUTOR command line. But the filter depends on
the operating system. To keep the Test Trigger configuration file operating system independent, the filter
is set in the Test Trigger code, but not in the configuration file.
Background: Some of the pytests depend on the operating system.
