### PR TITLE
Ntd1hc/hotfix/windows install texlive failed

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -20,43 +20,45 @@ env:
   DOCBUILDER_ARGUMENTS: --configfile "./maindoc_configs/maindoc_config_OSS.json"
 
 jobs:
-  # build-linux:
-  #   name: Build Linux package
-  #   runs-on: ubuntu-latest
+  build-linux:
+    name: Build Linux package
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout source
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
 
-  #     - name: Install dependencies
-  #       run: |
-  #         chmod +x ./requirements_linux.sh
-  #         ./requirements_linux.sh
+      - name: Install dependencies
+        run: |
+          chmod +x ./requirements_linux.sh
+          ./requirements_linux.sh
 
-  #     - name: Clone repositories
-  #       run: |
-  #         chmod +x ./cloneall
-  #         ./cloneall
+      - name: Clone repositories
+        run: |
+          chmod +x ./cloneall
+          ./cloneall
 
-  #     - name: Install
-  #       run: |
-  #         chmod +x ./install/install.sh
-  #         ./install/install.sh
+      - name: Install
+        run: |
+          chmod +x ./install/install.sh
+          ./install/install.sh
 
-  #     - name: Build
-  #       run: |
-  #         chmod +x ./build
-  #         ./build
+      - name: Build
+        run: |
+          chmod +x ./build
+          ./build
 
-  #     - name: Upload built package
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: linux-package
-  #         path: output_lx/*.deb
+      - name: Upload built package
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-package
+          path: output_lx/*.deb
 
   build-windows:
     name: Build Windows package
     runs-on: windows-latest
+    env:
+      GENDOC_LATEXPATH: C:/texlive/aio/bin/win32
     steps:
       - name: Support long path in git
         run: git config --system core.longpaths true
@@ -66,10 +68,7 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: |
-          ./requirements_windows.sh
-          echo $GENDOC_LATEXPATH
-          echo "GENDOC_LATEXPATH=$GENDOC_LATEXPATH" >> $GITHUB_ENV
+        run: ./requirements_windows.sh
 
       - name: Clone repositories
         shell: bash
@@ -89,114 +88,114 @@ jobs:
           name: windows-package
           path: Output/
 
-  # install-test-windows:
-  #   name: Test Windows package
-  #   runs-on: windows-latest
-  #   needs: build-windows
-  #   env:
-  #     RobotPythonPath: "C:/Program Files/RobotFramework/python39"
-  #     RobotTutorialPath: "C:/RobotTest/tutorial"
+  install-test-windows:
+    name: Test Windows package
+    runs-on: windows-latest
+    needs: build-windows
+    env:
+      RobotPythonPath: "C:/Program Files/RobotFramework/python39"
+      RobotTutorialPath: "C:/RobotTest/tutorial"
 
-  #   steps:
-  #   - name: Support long path in git
-  #     run: git config --system core.longpaths true
+    steps:
+    - name: Support long path in git
+      run: git config --system core.longpaths true
 
-  #   - name: Checkout source
-  #     uses: actions/checkout@v2
+    - name: Checkout source
+      uses: actions/checkout@v2
 
-  #   - name: Clone repositories
-  #     shell: bash
-  #     run: ./cloneall
+    - name: Clone repositories
+      shell: bash
+      run: ./cloneall
 
-  #   - name: Download Windows installer package
-  #     uses: actions/download-artifact@v2
-  #     with:
-  #       name: windows-package
+    - name: Download Windows installer package
+      uses: actions/download-artifact@v2
+      with:
+        name: windows-package
 
-  #   - name: Install RobotFramework AIO on Windows
-  #     shell: cmd
-  #     run: ./scripts/install-windows.bat
+    - name: Install RobotFramework AIO on Windows
+      shell: cmd
+      run: ./scripts/install-windows.bat
 
-  #   - name: Run tests on Windows
-  #     shell: cmd
-  #     run: |
-  #       set Robot
-  #       "%RobotPythonPath%/python" test/aio-test-trigger/aio-test-trigger.py
+    - name: Run tests on Windows
+      shell: cmd
+      run: |
+        set Robot
+        "%RobotPythonPath%/python" test/aio-test-trigger/aio-test-trigger.py
 
-  # install-test-linux:
-  #   name: Test Linux package
-  #   runs-on: ubuntu-latest
-  #   needs: build-linux
+  install-test-linux:
+    name: Test Linux package
+    runs-on: ubuntu-latest
+    needs: build-linux
 
-  #   steps:
-  #   - name: Checkout source
-  #     uses: actions/checkout@v2
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v2
 
-  #   - name: Clone repositories
-  #     run: |
-  #       chmod +x ./cloneall
-  #       ./cloneall
+    - name: Clone repositories
+      run: |
+        chmod +x ./cloneall
+        ./cloneall
 
-  #   - name: Download Linux installer package
-  #     uses: actions/download-artifact@v2
-  #     with:
-  #       name: linux-package
+    - name: Download Linux installer package
+      uses: actions/download-artifact@v2
+      with:
+        name: linux-package
 
-  #   - name: Install on Linux
-  #     run: |
-  #       sudo apt-get update
-  #       sudo apt-get install ./*.deb --fix-missing
+    - name: Install on Linux
+      run: |
+        sudo apt-get update
+        sudo apt-get install ./*.deb --fix-missing
 
-  #   - name: Run tests on Linux
-  #     run: |
-  #       . /opt/rfwaio/linux/set_robotenv.sh
-  #       printenv | grep Robot
-  #       echo $(which pandoc)
-  #       $RobotPythonPath/python3.9 test/aio-test-trigger/aio-test-trigger.py
+    - name: Run tests on Linux
+      run: |
+        . /opt/rfwaio/linux/set_robotenv.sh
+        printenv | grep Robot
+        echo $(which pandoc)
+        $RobotPythonPath/python3.9 test/aio-test-trigger/aio-test-trigger.py
 
-  # release:
-    # name: Release AIO
-    # runs-on: ubuntu-latest
-    # needs: [install-test-windows, install-test-linux]
-    # if: github.ref_type == 'tag'
+  release:
+    name: Release AIO
+    runs-on: ubuntu-latest
+    needs: [install-test-windows, install-test-linux]
+    if: github.ref_type == 'tag'
 
-    # steps:
-    # - name: Download artifact from build workflow
-    #   uses: actions/download-artifact@v2
+    steps:
+    - name: Download artifact from build workflow
+      uses: actions/download-artifact@v2
 
-    # - name: Get released file names
-    #   run: |
-    #     echo "EXE_FILE=$(ls windows-package/*.exe | head -1)" >> $GITHUB_ENV
-    #     echo "DEB_FILE=$(ls linux-package/*.deb | head -1)" >> $GITHUB_ENV
-    #     echo "RELEASE_VERSION=${TAG_NAME#rel/aio/}" >> $GITHUB_ENV
+    - name: Get released file names
+      run: |
+        echo "EXE_FILE=$(ls windows-package/*.exe | head -1)" >> $GITHUB_ENV
+        echo "DEB_FILE=$(ls linux-package/*.deb | head -1)" >> $GITHUB_ENV
+        echo "RELEASE_VERSION=${TAG_NAME#rel/aio/}" >> $GITHUB_ENV
 
-    # - name: Create Release
-    #   id: create_release
-    #   uses: actions/create-release@v1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     tag_name: ${{ env.TAG_NAME }}
-    #     release_name: RobotFramework AIO version ${{ env.RELEASE_VERSION }}
-    #     draft: false
-    #     prerelease: false
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ env.TAG_NAME }}
+        release_name: RobotFramework AIO version ${{ env.RELEASE_VERSION }}
+        draft: false
+        prerelease: false
 
-    # - name: Upload Windows Release Asset
-    #   uses: actions/upload-release-asset@v1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-    #     asset_path: ${{ env.EXE_FILE }}
-    #     asset_name: setup_RobotFramework_AIO_Win_${{ env.RELEASE_VERSION }}.exe
-    #     asset_content_type: application/octet-stream
+    - name: Upload Windows Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ env.EXE_FILE }}
+        asset_name: setup_RobotFramework_AIO_Win_${{ env.RELEASE_VERSION }}.exe
+        asset_content_type: application/octet-stream
 
-    # - name: Upload Linux Release Asset
-    #   uses: actions/upload-release-asset@v1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-    #     asset_path: ${{ env.DEB_FILE }}
-    #     asset_name: setup_RobotFramework_AIO_Linux_${{ env.RELEASE_VERSION }}.deb
-    #     asset_content_type: application/vnd.debian.binary-package
+    - name: Upload Linux Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ env.DEB_FILE }}
+        asset_name: setup_RobotFramework_AIO_Linux_${{ env.RELEASE_VERSION }}.deb
+        asset_content_type: application/vnd.debian.binary-package

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -20,45 +20,43 @@ env:
   DOCBUILDER_ARGUMENTS: --configfile "./maindoc_configs/maindoc_config_OSS.json"
 
 jobs:
-  build-linux:
-    name: Build Linux package
-    runs-on: ubuntu-latest
+  # build-linux:
+  #   name: Build Linux package
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout source
+  #       uses: actions/checkout@v2
 
-      - name: Install dependencies
-        run: |
-          chmod +x ./requirements_linux.sh
-          ./requirements_linux.sh
+  #     - name: Install dependencies
+  #       run: |
+  #         chmod +x ./requirements_linux.sh
+  #         ./requirements_linux.sh
 
-      - name: Clone repositories
-        run: |
-          chmod +x ./cloneall
-          ./cloneall
+  #     - name: Clone repositories
+  #       run: |
+  #         chmod +x ./cloneall
+  #         ./cloneall
 
-      - name: Install
-        run: |
-          chmod +x ./install/install.sh
-          ./install/install.sh
+  #     - name: Install
+  #       run: |
+  #         chmod +x ./install/install.sh
+  #         ./install/install.sh
 
-      - name: Build
-        run: |
-          chmod +x ./build
-          ./build
+  #     - name: Build
+  #       run: |
+  #         chmod +x ./build
+  #         ./build
 
-      - name: Upload built package
-        uses: actions/upload-artifact@v3
-        with:
-          name: linux-package
-          path: output_lx/*.deb
+  #     - name: Upload built package
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: linux-package
+  #         path: output_lx/*.deb
 
   build-windows:
     name: Build Windows package
     runs-on: windows-latest
-    env:
-      GENDOC_LATEXPATH: C:/texlive/2022/bin/win32
     steps:
       - name: Support long path in git
         run: git config --system core.longpaths true
@@ -68,7 +66,10 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: ./requirements_windows.sh
+        run: |
+          ./requirements_windows.sh
+          echo $GENDOC_LATEXPATH
+          echo "GENDOC_LATEXPATH=$GENDOC_LATEXPATH" >> $GITHUB_ENV
 
       - name: Clone repositories
         shell: bash
@@ -88,114 +89,114 @@ jobs:
           name: windows-package
           path: Output/
 
-  install-test-windows:
-    name: Test Windows package
-    runs-on: windows-latest
-    needs: build-windows
-    env:
-      RobotPythonPath: "C:/Program Files/RobotFramework/python39"
-      RobotTutorialPath: "C:/RobotTest/tutorial"
+  # install-test-windows:
+  #   name: Test Windows package
+  #   runs-on: windows-latest
+  #   needs: build-windows
+  #   env:
+  #     RobotPythonPath: "C:/Program Files/RobotFramework/python39"
+  #     RobotTutorialPath: "C:/RobotTest/tutorial"
 
-    steps:
-    - name: Support long path in git
-      run: git config --system core.longpaths true
+  #   steps:
+  #   - name: Support long path in git
+  #     run: git config --system core.longpaths true
 
-    - name: Checkout source
-      uses: actions/checkout@v2
+  #   - name: Checkout source
+  #     uses: actions/checkout@v2
 
-    - name: Clone repositories
-      shell: bash
-      run: ./cloneall
+  #   - name: Clone repositories
+  #     shell: bash
+  #     run: ./cloneall
 
-    - name: Download Windows installer package
-      uses: actions/download-artifact@v2
-      with:
-        name: windows-package
+  #   - name: Download Windows installer package
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: windows-package
 
-    - name: Install RobotFramework AIO on Windows
-      shell: cmd
-      run: ./scripts/install-windows.bat
+  #   - name: Install RobotFramework AIO on Windows
+  #     shell: cmd
+  #     run: ./scripts/install-windows.bat
 
-    - name: Run tests on Windows
-      shell: cmd
-      run: |
-        set Robot
-        "%RobotPythonPath%/python" test/aio-test-trigger/aio-test-trigger.py
+  #   - name: Run tests on Windows
+  #     shell: cmd
+  #     run: |
+  #       set Robot
+  #       "%RobotPythonPath%/python" test/aio-test-trigger/aio-test-trigger.py
 
-  install-test-linux:
-    name: Test Linux package
-    runs-on: ubuntu-latest
-    needs: build-linux
+  # install-test-linux:
+  #   name: Test Linux package
+  #   runs-on: ubuntu-latest
+  #   needs: build-linux
 
-    steps:
-    - name: Checkout source
-      uses: actions/checkout@v2
+  #   steps:
+  #   - name: Checkout source
+  #     uses: actions/checkout@v2
 
-    - name: Clone repositories
-      run: |
-        chmod +x ./cloneall
-        ./cloneall
+  #   - name: Clone repositories
+  #     run: |
+  #       chmod +x ./cloneall
+  #       ./cloneall
 
-    - name: Download Linux installer package
-      uses: actions/download-artifact@v2
-      with:
-        name: linux-package
+  #   - name: Download Linux installer package
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: linux-package
 
-    - name: Install on Linux
-      run: |
-        sudo apt-get update
-        sudo apt-get install ./*.deb --fix-missing
+  #   - name: Install on Linux
+  #     run: |
+  #       sudo apt-get update
+  #       sudo apt-get install ./*.deb --fix-missing
 
-    - name: Run tests on Linux
-      run: |
-        . /opt/rfwaio/linux/set_robotenv.sh
-        printenv | grep Robot
-        echo $(which pandoc)
-        $RobotPythonPath/python3.9 test/aio-test-trigger/aio-test-trigger.py
+  #   - name: Run tests on Linux
+  #     run: |
+  #       . /opt/rfwaio/linux/set_robotenv.sh
+  #       printenv | grep Robot
+  #       echo $(which pandoc)
+  #       $RobotPythonPath/python3.9 test/aio-test-trigger/aio-test-trigger.py
 
-  release:
-    name: Release AIO
-    runs-on: ubuntu-latest
-    needs: [install-test-windows, install-test-linux]
-    if: github.ref_type == 'tag'
+  # release:
+    # name: Release AIO
+    # runs-on: ubuntu-latest
+    # needs: [install-test-windows, install-test-linux]
+    # if: github.ref_type == 'tag'
 
-    steps:
-    - name: Download artifact from build workflow
-      uses: actions/download-artifact@v2
+    # steps:
+    # - name: Download artifact from build workflow
+    #   uses: actions/download-artifact@v2
 
-    - name: Get released file names
-      run: |
-        echo "EXE_FILE=$(ls windows-package/*.exe | head -1)" >> $GITHUB_ENV
-        echo "DEB_FILE=$(ls linux-package/*.deb | head -1)" >> $GITHUB_ENV
-        echo "RELEASE_VERSION=${TAG_NAME#rel/aio/}" >> $GITHUB_ENV
+    # - name: Get released file names
+    #   run: |
+    #     echo "EXE_FILE=$(ls windows-package/*.exe | head -1)" >> $GITHUB_ENV
+    #     echo "DEB_FILE=$(ls linux-package/*.deb | head -1)" >> $GITHUB_ENV
+    #     echo "RELEASE_VERSION=${TAG_NAME#rel/aio/}" >> $GITHUB_ENV
 
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ env.TAG_NAME }}
-        release_name: RobotFramework AIO version ${{ env.RELEASE_VERSION }}
-        draft: false
-        prerelease: false
+    # - name: Create Release
+    #   id: create_release
+    #   uses: actions/create-release@v1
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     tag_name: ${{ env.TAG_NAME }}
+    #     release_name: RobotFramework AIO version ${{ env.RELEASE_VERSION }}
+    #     draft: false
+    #     prerelease: false
 
-    - name: Upload Windows Release Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ${{ env.EXE_FILE }}
-        asset_name: setup_RobotFramework_AIO_Win_${{ env.RELEASE_VERSION }}.exe
-        asset_content_type: application/octet-stream
+    # - name: Upload Windows Release Asset
+    #   uses: actions/upload-release-asset@v1
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+    #     asset_path: ${{ env.EXE_FILE }}
+    #     asset_name: setup_RobotFramework_AIO_Win_${{ env.RELEASE_VERSION }}.exe
+    #     asset_content_type: application/octet-stream
 
-    - name: Upload Linux Release Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ${{ env.DEB_FILE }}
-        asset_name: setup_RobotFramework_AIO_Linux_${{ env.RELEASE_VERSION }}.deb
-        asset_content_type: application/vnd.debian.binary-package
+    # - name: Upload Linux Release Asset
+    #   uses: actions/upload-release-asset@v1
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+    #     asset_path: ${{ env.DEB_FILE }}
+    #     asset_name: setup_RobotFramework_AIO_Linux_${{ env.RELEASE_VERSION }}.deb
+    #     asset_content_type: application/vnd.debian.binary-package

--- a/requirements_windows.sh
+++ b/requirements_windows.sh
@@ -30,7 +30,13 @@ texlive_packages=(
 #   extra_packages+="$package,"
 # done
 
-TEXLIVE_DIR="C:/texlive/aio"
+if [ -n $GENDOC_LATEXPATH ]; then
+  TEXLIVE_DIR=${GENDOC_LATEXPATH%/bin/win32}
+else
+  TEXLIVE_DIR="C:/texlive/aio"
+  export GENDOC_LATEXPATH="${TEXLIVE_DIR}/bin/win32"
+fi
+
 # choco install texlive --version=2022.20221202 --params "'/collections:pictures,latex,latexextra,latexrecommended'" --execution-timeout 5400
 choco install texlive --params "'/collections:pictures,latex /InstallationPath:${TEXLIVE_DIR}'"
 
@@ -43,5 +49,3 @@ $tlmgr update --self --all
 for package in ${texlive_packages[@]}; do
   $tlmgr install "$package"
 done
-
-export GENDOC_LATEXPATH="${TEXLIVE_DIR}/bin/win32"

--- a/requirements_windows.sh
+++ b/requirements_windows.sh
@@ -25,9 +25,23 @@ texlive_packages=(
 "listings"
 "pdfcol"
 )
-extra_packages=""
+# extra_packages=""
+# for package in ${texlive_packages[@]}; do
+#   extra_packages+="$package,"
+# done
+
+TEXLIVE_DIR="C:/texlive/aio"
+# choco install texlive --version=2022.20221202 --params "'/collections:pictures,latex,latexextra,latexrecommended'" --execution-timeout 5400
+choco install texlive --params "'/collections:pictures,latex /InstallationPath:${TEXLIVE_DIR}'"
+
+tlmgr="${TEXLIVE_DIR}/bin/win32/tlmgr.bat"
+
+# Update TeX Live package database
+$tlmgr update --self --all
+
+# Install each package in the list
 for package in ${texlive_packages[@]}; do
-  extra_packages+="$package,"
+  $tlmgr install "$package"
 done
 
-choco install texlive --version=2022.20221202 --params "'/collections:pictures,latex /extraPackages:${extra_packages::-1}'"
+export GENDOC_LATEXPATH="${TEXLIVE_DIR}/bin/win32"


### PR DESCRIPTION
Hi Thomas,

After investigating I found that the extra packages installation which is handled by `choco` (choco defines the script to handle this installation) does not work properly. 
The location of `tlmgr` (is used to install packages) maybe not correct due to upgraded version of TexLive from 2022 to 2023.

I moved extra packages installation to our script and it works fine now.

Thank you,
Ngoan