### PR TITLE
update path to binary folder as new texlive version

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -57,8 +57,6 @@ jobs:
   build-windows:
     name: Build Windows package
     runs-on: windows-latest
-    env:
-      GENDOC_LATEXPATH: C:/texlive/aio/bin/win32
     steps:
       - name: Support long path in git
         run: git config --system core.longpaths true
@@ -68,7 +66,9 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: ./requirements_windows.sh
+        run: |
+          . ./requirements_windows.sh
+          echo "GENDOC_LATEXPATH=$GENDOC_LATEXPATH" >> $GITHUB_ENV
 
       - name: Clone repositories
         shell: bash

--- a/requirements_windows.sh
+++ b/requirements_windows.sh
@@ -25,27 +25,14 @@ texlive_packages=(
 "listings"
 "pdfcol"
 )
-# extra_packages=""
-# for package in ${texlive_packages[@]}; do
-#   extra_packages+="$package,"
-# done
+extra_packages=""
+for package in ${texlive_packages[@]}; do
+  extra_packages+="$package,"
+done
 
-if [ -n $GENDOC_LATEXPATH ]; then
-  TEXLIVE_DIR=${GENDOC_LATEXPATH%/bin/win32}
-else
-  TEXLIVE_DIR="C:/texlive/aio"
-  export GENDOC_LATEXPATH="${TEXLIVE_DIR}/bin/win32"
-fi
+TEXLIVE_DIR="C:/texlive/aio"
 
 # choco install texlive --version=2022.20221202 --params "'/collections:pictures,latex,latexextra,latexrecommended'" --execution-timeout 5400
-choco install texlive --params "'/collections:pictures,latex /InstallationPath:${TEXLIVE_DIR}'"
+choco install texlive --params "'/collections:pictures,latex /InstallationPath:${TEXLIVE_DIR} /extraPackages:${extra_packages}'"
 
-tlmgr="${TEXLIVE_DIR}/bin/win32/tlmgr.bat"
-
-# Update TeX Live package database
-$tlmgr update --self --all
-
-# Install each package in the list
-for package in ${texlive_packages[@]}; do
-  $tlmgr install "$package"
-done
+export GENDOC_LATEXPATH="${TEXLIVE_DIR}/bin/windows"


### PR DESCRIPTION
Hi Thomas,

The Windows binary location has been changed (from `bin/win32` to `bin/windows`) in the latest released texlive version on chocolatey - **2023.20230321**.

I have avoided to use latest texlive version (incompatable, potential issues, ....) in my initial implement by specify the version for installation but issue has been come when version **2023.********** has been released. I have checked I faced some errors (from installation script of `choco`) when trying to use old (2022) versions.

I have reverted my change to previous implement (to let `choco `handle the installation of extra package) because I observed that `choco `has handled it by updating its installation script and it works fine now. Besides, env var `GENDOC_LATEXPATH` is also updated due to binary location change.

Pipeline is working fine with new adaption: https://github.com/test-fullautomation/RobotFramework_AIO/actions/runs/4507883969
Hope that the new Windows released texlive version will not effect our pipeline again.

Thank you,
Ngoan