### PR TITLE
Ntd1hc/feat/store aio test logfiles as artifact

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -148,8 +148,12 @@ jobs:
       if: success() || failure()
       uses: actions/upload-artifact@v3
       with:
-        name: Windows-aiotestlogfiles
-        path: ${{ runner.workspace }}/**/*/aiotestlogfiles/*
+        name: windows-aiotestlogfiles
+        # long path issue on Windows when upload artifact 
+        # https://github.com/actions/upload-artifact/issues/240
+        path: |
+          ${{ runner.workspace }}/[Rr]obotframework*/**/*/aiotestlogfiles/*
+          ${{ runner.workspace }}/[Pp]ython*/**/*/aiotestlogfiles/*
 
   install-test-linux:
     name: Test Linux package
@@ -186,7 +190,7 @@ jobs:
       if: success() || failure()
       uses: actions/upload-artifact@v3
       with:
-        name: Linux-aiotestlogfiles
+        name: linux-aiotestlogfiles
         path: ${{ runner.workspace }}/**/*/aiotestlogfiles/*
 
   release:

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -144,6 +144,13 @@ jobs:
         set Robot
         "%RobotPythonPath%/python" test/aio-test-trigger/aio-test-trigger.py
 
+    - name: Upload test result as artifact
+      if: success() || failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: Windows-aiotestlogfiles
+        path: ${{ runner.workspace }}/**/*/aiotestlogfiles/*
+
   install-test-linux:
     name: Test Linux package
     runs-on: ubuntu-latest
@@ -174,6 +181,13 @@ jobs:
         printenv | grep Robot
         echo $(which pandoc)
         $RobotPythonPath/python3.9 test/aio-test-trigger/aio-test-trigger.py
+
+    - name: Upload test result as artifact
+      if: success() || failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: Linux-aiotestlogfiles
+        path: ${{ runner.workspace }}/**/*/aiotestlogfiles/*
 
   release:
     name: Release AIO

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -114,6 +114,7 @@ jobs:
     name: Test Windows package
     runs-on: windows-latest
     needs: build-windows
+    if: ${{ ! failure() && ! cancelled() }}
     env:
       RobotPythonPath: "C:/Program Files/RobotFramework/python39"
       RobotTutorialPath: "C:/RobotTest/tutorial"
@@ -159,6 +160,7 @@ jobs:
     name: Test Linux package
     runs-on: ubuntu-latest
     needs: build-linux
+    if: ${{ ! failure() && ! cancelled() }}
 
     steps:
     - name: Checkout source
@@ -197,7 +199,7 @@ jobs:
     name: Release AIO
     runs-on: ubuntu-latest
     needs: [install-test-windows, install-test-linux]
-    if: github.ref_type == 'tag'
+    if: ${{ ! failure() && ! cancelled() && github.ref_type == 'tag' }}
 
     steps:
     - name: Download artifact from build workflow


### PR DESCRIPTION
Hi Thomas,

This PR fixed the side-affect that test jobs are skipped when adding tag job.
Besides, I also added steps in test jobs to store all test trigger result/log files as the artifact. (I am testing this enhancement with gitlab CI for BIOS pipeline)

Thank you,
Ngoan