### PR TITLE
add vscode extension jsonp for build pipeline

### DIFF
--- a/config/repositories/repositories.conf
+++ b/config/repositories/repositories.conf
@@ -19,6 +19,7 @@ robotframework-robotlog2db=
 
 testresultwebapp=
 robotframework-documentation=
+vscode-jsonp=
 
 [supported-server]
 github=https://github.com/test-fullautomation

--- a/config/repositories/tag_repos.json
+++ b/config/repositories/tag_repos.json
@@ -17,7 +17,8 @@
          "robotframework-selftest": "",
          "robotframework-testsuitesmanagement": "",
          "robotframework-tutorial": "",
-         "testresultwebapp": ""
+         "testresultwebapp": "",
+         "vscode-jsonp": ""
       }
    }
 }

--- a/install/install.sh
+++ b/install/install.sh
@@ -23,6 +23,7 @@ mypath=$(realpath $(dirname $0))
 sourceDir=$mypath/../download
 vscodeData=$mypath/../config/robotvscode/
 vscodeIcons=$mypath/../config/robotvscode/icons
+vscode_jsonp=$mypath/../../vscode-jsonp/jsonp-?.?.?.vsix
 destDir=$(realpath $mypath/../..)
 
 use_cntlm="No"
@@ -63,7 +64,7 @@ function parse_arg() {
 		--use-cntlm) echo "Using cntlm";use_cntlm="Yes"; shift;;
 		--python) echo "Create Python repo only";python_only="Yes"; shift;;
 		--vscode) echo "Create vscode repo only";vscode_only="Yes"; shift;;
-		--pandoc) echo "Create vscode repo only";pandoc_only="Yes"; shift;;
+		--pandoc) echo "Create pandoc repo only";pandoc_only="Yes"; shift;;
 
 		-*) echo "unknown option: $1" >&2; exit 1;;
 	esac
@@ -139,6 +140,14 @@ function packaging_vscode() {
 		logresult "$?" "installed ${extfile#$vscodeData/extensions/} Extension" "install ${extfile#$vscodeData/extensions/} Extension"
 	done
 
+	if [ -f ${vscode_jsonp} ]; then
+		jsonp_ext_pathfile=$(ls ${vscode_jsonp})
+		json_ext_filename=$(basename $jsonp_ext_pathfile)
+		echo "Install ${json_ext_filename} extension from vscode-jsonp repo"
+		"$sourceDir/vscodium/bin/codium" --install-extension "${jsonp_ext_pathfile}" --user-data-dir "$sourceDir/vscodium/data"
+		logresult "$?" "installed ${jsonp_ext_file} Extension" "install ${jsonp_ext_file} Extension"
+	fi
+
 	echo "Install extension for visual codium defined in $mypath/vscode_requirement.csv"
 	while IFS=, read -r publisher name version dump
 	do
@@ -154,7 +163,7 @@ function packaging_vscode() {
 			logresult "$?" "installed ${name}-${version}.vsix Extension" "install ${name}-${version}.vsix Extension"
 		fi
 	done < "$mypath/vscode_requirement.csv"
-	
+
 	echo "Creating preconfigured VSCodium repository ..."
 	cp -R -a "$vscodeIcons/." "$sourceDir/vscodium/icons"
 


### PR DESCRIPTION
Hi Thomas,

This PR contains changes for issue #81 :
- Adding `vscode-jsonp` repo for OSS build pipeline
- Installing `jsonp` extension for VSCodium in installation step.

Currently, I do dot change the VSCodium setting for `*.json` file association (still `jsonc`), `*.jsonp` file will be automatically associated with our `jsonp `extension.

Please review and give your felling it.

Thank you,
Ngoan