### PR TITLE
update github action with env var changes for genmaindoc

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -18,7 +18,8 @@ env:
   TAG_NAME: ${{ github.ref_name }}
   REF_NAME: ${{ github.ref_name }}
   DEFAULT_REF: ${{ github.base_ref }}
-  DOCBUILDER_ARGUMENTS: --configfile "./maindoc_configs/maindoc_config_OSS.json"
+  MAINDOC_CONFIGFILE: --configfile "./maindoc/maindoc_configs/maindoc_config_OSS.json"
+  BUNDLE_NAME: --bundle_name "RobotFramework AIO"
 
 jobs:
   tag-repos:
@@ -47,10 +48,12 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
 
-      - name: Install dependencies
+      - name: Install dependencies and set environment variables
         run: |
           chmod +x ./requirements_linux.sh
           ./requirements_linux.sh
+          echo "BUNDLE_VERSION_DATE=--bundle_version_date \"$(date +%m.%Y)\"" >> $GITHUB_ENV
+          echo "BUNDLE_VERSION=--bundle_version \"${TAG_NAME#rel/aio/}\"" >> $GITHUB_ENV
 
       - name: Clone repositories
         run: |
@@ -86,11 +89,13 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
 
-      - name: Install dependencies
+      - name: Install dependencies and set environment variables
         shell: bash
         run: |
           . ./requirements_windows.sh
           echo "GENDOC_LATEXPATH=$GENDOC_LATEXPATH" >> $GITHUB_ENV
+          echo "BUNDLE_VERSION_DATE=--bundle_version_date \"$(date +%m.%Y)\"" >> $GITHUB_ENV
+          echo "BUNDLE_VERSION=--bundle_version \"${TAG_NAME#rel/aio/}\"" >> $GITHUB_ENV
 
       - name: Clone repositories
         shell: bash


### PR DESCRIPTION
Hi Thomas,

This PR contains the adaption for OSS build pipeline due to env var changes.

Notes: _the version number is extracted from release tag (**rel/aio/x.x.x.x**) so when executing this OSS pipeline without release tag (merge PR or trigger manually to test feature branches), the version info in generated pdf document will be the branch name.
The sample generated pdf file for this feature branch [RobotFrameworkAIO_Reference.pdf](https://github.com/test-fullautomation/RobotFramework_AIO/files/11483489/RobotFrameworkAIO_Reference.pdf)_

Thank you,
Ngoan