### PR TITLE
Agt2hc/hotfix/fix incorrect version number for linux build

### DIFF
--- a/build
+++ b/build
@@ -252,6 +252,7 @@ function build_debian()
 	# read 2. line, from there return after 10th character
 	VERSION=`sed '2q;d' ./config/build/dpkg_build/control | cut -c 10-`
 	overwrite_testsuitmanagement_version $VERSION
+	VERSION=`sed '2q;d' ./config/build/dpkg_build/control | cut -c 10-`
 	parse_config $ConfigFile
 
 	cd $CURDIR
@@ -319,6 +320,7 @@ function build_windows() {
 
 	VERSION=`sed '2q;d' ./config/build/dpkg_build/control | cut -c 10-`
 	overwrite_testsuitmanagement_version $VERSION
+	VERSION=`sed '2q;d' ./config/build/dpkg_build/control | cut -c 10-`
 
 	parse_config $ConfigFile
 

--- a/include/bash/common.sh
+++ b/include/bash/common.sh
@@ -55,9 +55,9 @@ function overwrite_testsuitmanagement_version(){
 
 	if [ ../robotframework-testsuitesmanagement/RobotFramework_TestsuitesManagement/Config/CConfig.py ]
 	then
-		export DATE=`date +%m.%4Y`
-		export VERSION_DATE="VERSION_DATE    = \"$DATE\""
-		export VERSION="VERSION         = \"$1\""
+		DATE=`date +%m.%4Y`
+		VERSION_DATE="VERSION_DATE    = \"$DATE\""
+		VERSION="VERSION         = \"$1\""
 		sed -ie '/AIO_BUNDLE_NAME/{n;N;d}' ../robotframework-testsuitesmanagement/RobotFramework_TestsuitesManagement/Config/CConfig.py
 
 		sed -i "/AIO_BUNDLE_NAME/a$VERSION_DATE" ../robotframework-testsuitesmanagement/RobotFramework_TestsuitesManagement/Config/CConfig.py


### PR DESCRIPTION
- Fixed linux build failed due to recent testsuite_management version overwrite scripts