### PR TITLE
remove GENDOC_PLANTUML_PATH env var from installer, correct its setting for build pipeline

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -20,6 +20,7 @@ env:
   DEFAULT_REF: ${{ github.base_ref }}
   MAINDOC_CONFIGFILE: --configfile "./maindoc/maindoc_configs/maindoc_config_OSS.json"
   BUNDLE_NAME: --bundle_name "RobotFramework AIO"
+  GENDOC_PLANTUML_PATH: "../robotvscode/data/extensions/jebbs.plantuml-2.17.5"
 
 jobs:
   tag-repos:
@@ -123,7 +124,7 @@ jobs:
     env:
       RobotPythonPath: "C:/Program Files/RobotFramework/python39"
       RobotTutorialPath: "C:/RobotTest/tutorial"
-      GENDOC_PLANTUML_PATH: "C:/Program Files/RobotFramework/robotvscode/data/extensions/jebbs.plantuml-2.17.5-universal"
+      GENDOC_PLANTUML_PATH: "C:/Program Files/RobotFramework/robotvscode/data/extensions/jebbs.plantuml-2.17.5"
 
     steps:
     - name: Support long path in git
@@ -190,8 +191,7 @@ jobs:
     - name: Run tests on Linux
       run: |
         . /opt/rfwaio/linux/set_robotenv.sh
-        printenv | grep Robot
-        echo $(which pandoc)
+        export GENDOC_PLANTUML_PATH=$RobotVsCode/data/extensions/jebbs.plantuml-2.17.5
         $RobotPythonPath/python3.9 test/aio-test-trigger/aio-test-trigger.py
 
     - name: Upload test result as artifact

--- a/requirements_windows.sh
+++ b/requirements_windows.sh
@@ -36,5 +36,3 @@ TEXLIVE_DIR="C:/texlive/aio"
 choco install texlive --params "'/collections:pictures,latex /InstallationPath:${TEXLIVE_DIR} /extraPackages:${extra_packages}'"
 
 export GENDOC_LATEXPATH="${TEXLIVE_DIR}/bin/windows"
-export RobotPlantUMLPath="../robotvscode/data/extensions/jebbs.plantuml-2.17.5-universal"
-export GENDOC_PLANTUML_PATH="${RobotPlantUMLPath}"

--- a/scripts/RobotFrameworkSetup.iss
+++ b/scripts/RobotFrameworkSetup.iss
@@ -170,7 +170,7 @@ Root: HKLM; SubKey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environmen
 Root: HKLM; SubKey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: string; ValueName: RobotTestPath; ValueData: {code:GetUsrDataDir}\testcases;
 Root: HKLM; SubKey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: string; ValueName: RobotLogPath; ValueData: {code:GetUsrDataDir}\logfiles;
 Root: HKLM; SubKey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: string; ValueName: RobotTutorialPath; ValueData: {code:GetUsrDataDir}\tutorial;
-Root: HKLM; SubKey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: string; ValueName: GENDOC_PLANTUML_PATH; ValueData: {app}\robotvscode\data\extensions\jebbs.plantuml-2.17.5-universal;
+Root: HKLM; SubKey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: string; ValueName: GENDOC_PLANTUML_PATH; ValueData: {app}\robotvscode\data\extensions\jebbs.plantuml-2.17.5;
 
 
 ; ROBFW Doesn't change ANDROID_HOME


### PR DESCRIPTION
Hi Thomas,
Hi Holger,

This PR contains changes for `GENDOC_PLANTUML_PATH` in build pipeline as issue https://github.com/test-fullautomation/python-genpackagedoc/issues/41.

It does not contains the `GENDOC_PLANTUML_PATH` setting in the installers as my comment https://github.com/test-fullautomation/python-genpackagedoc/issues/41#issuecomment-1560796095.
So, the additional commit will be added if  the `GENDOC_PLANTUML_PATH` is still required for the installers.

Thank you,
Ngoan