### PR TITLE
use release status badge instead of the default one

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 -->
 
 # Robot Framework AIO  <!-- omit in toc -->
-[![Build RobotFramework AIO packages](https://github.com/test-fullautomation/RobotFramework_AIO/actions/workflows/build_robotframework_aio.yml/badge.svg)](https://github.com/test-fullautomation/RobotFramework_AIO/actions/workflows/build_robotframework_aio.yml)
+[![Build RobotFramework AIO packages](https://github.com/test-fullautomation/RobotFramework_AIO/actions/workflows/build_robotframework_aio.yml/badge.svg?event=push)](https://github.com/test-fullautomation/RobotFramework_AIO/actions/workflows/build_robotframework_aio.yml)
 
 This respository holds the build tooling for a new Robot Framework AIO (All In 
 One) setup for both Windows and Linux.


### PR DESCRIPTION
Hi Thomas,

This update changes the status badge which is used in README file.
Currently, it uses the default setting which is displayed as `failing`.

I change to use the status of workflow which is triggered by push event (new release tag).
This will properly reflect the status of the workflow for releasing.

Thank you,
Ngoan