### PR TITLE
Ntd1hc/feat/update version info in debian control file due to tag

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -218,7 +218,7 @@ jobs:
     name: Release AIO
     runs-on: ubuntu-latest
     needs: [install-test-windows, install-test-linux]
-    if: ${{ ! failure() && ! cancelled() && github.ref_type == 'tag' }}
+    if: ${{ ! failure() && ! cancelled() && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/rel/aio/') }}
 
     steps:
     - name: Download artifact from build workflow
@@ -265,7 +265,7 @@ jobs:
     name: Tag Python packages to trigger workflow for publishing to PyPI
     runs-on: ubuntu-latest
     needs: [install-test-windows, install-test-linux]
-    if: ${{ ! failure() && ! cancelled() && github.ref_type == 'tag' }}
+    if: ${{ ! failure() && ! cancelled() && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/rel/aio/') }}
 
     steps:
     - name: Checkout source

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -57,9 +57,9 @@ jobs:
           chmod +x ./requirements_linux.sh
           ./requirements_linux.sh
           echo "AIO_VERSION_DATE=$(date +%m.%Y)" >> $GITHUB_ENV
-          echo "AIO_VERSION=${TAG_NAME#rel/aio/}" >> $GITHUB_ENV
+          echo "AIO_VERSION=${TAG_NAME#[rd]e[vl]/aio/}" >> $GITHUB_ENV
           echo "BUNDLE_VERSION_DATE=--bundle_version_date \"$(date +%m.%Y)\"" >> $GITHUB_ENV
-          echo "BUNDLE_VERSION=--bundle_version \"${TAG_NAME#rel/aio/}\"" >> $GITHUB_ENV
+          echo "BUNDLE_VERSION=--bundle_version \"${TAG_NAME#[rd]e[vl]/aio/}\"" >> $GITHUB_ENV
 
       - name: Clone repositories
         run: |
@@ -101,9 +101,9 @@ jobs:
           . ./requirements_windows.sh
           echo "GENDOC_LATEXPATH=$GENDOC_LATEXPATH" >> $GITHUB_ENV
           echo "AIO_VERSION_DATE=$(date +%m.%Y)" >> $GITHUB_ENV
-          echo "AIO_VERSION=${TAG_NAME#rel/aio/}" >> $GITHUB_ENV
+          echo "AIO_VERSION=${TAG_NAME#[rd]e[vl]/aio/}" >> $GITHUB_ENV
           echo "BUNDLE_VERSION_DATE=--bundle_version_date \"$(date +%m.%Y)\"" >> $GITHUB_ENV
-          echo "BUNDLE_VERSION=--bundle_version \"${TAG_NAME#rel/aio/}\"" >> $GITHUB_ENV
+          echo "BUNDLE_VERSION=--bundle_version \"${TAG_NAME#[rd]e[vl]/aio/}\"" >> $GITHUB_ENV
 
       - name: Clone repositories
         shell: bash

--- a/build
+++ b/build
@@ -257,7 +257,7 @@ function build_debian()
 	echo -e "${COL_GREEN}#          Executing dpkg to create installer...                                   #${COL_RESET}"
 	echo -e "${COL_GREEN}####################################################################################${COL_RESET}"
 
-	PACK_NAME=RobotFramework_AIO_${VERSION}
+	PACK_NAME=RobotFramework_AIO_${AIO_VERSION}
 
 	#first cleanup
 	rm -rf ./output_lx/${PACK_NAME}/

--- a/build
+++ b/build
@@ -249,6 +249,7 @@ function build_debian()
 {
 	check_and_install_texlive
 	create_testsuitmanagement_package_context_file
+	update_debian_control_file
 	parse_config $ConfigFile
 
 	cd $CURDIR

--- a/include/bash/common.sh
+++ b/include/bash/common.sh
@@ -80,6 +80,13 @@ function create_testsuitmanagement_package_context_file(){
 	echo "$package_context" > "$package_context_pathfile"
 	logresult "$?" "created '$package_context_pathfile'" "create '$package_context_pathfile'"
 }
+
+function update_debian_control_file(){
+	if [[ "$AIO_VERSION" =~ $VERSION_REGEX ]] && [ "$AIO_VERSION" != "$VERSION" ]; then
+		echo "Update version info in control file to '$AIO_VERSION'"
+		sed -i "s/\(Version: \)[0-9].[0-9].[0-9].[0-9]/\1$AIO_VERSION/" $control_pathfile
+	fi
+}
 # Clone or update repository
 # Arguments:
 #	$repo_path : location to clone repo into

--- a/include/bash/common.sh
+++ b/include/bash/common.sh
@@ -84,7 +84,7 @@ function create_testsuitmanagement_package_context_file(){
 function update_debian_control_file(){
 	if [[ "$AIO_VERSION" =~ $VERSION_REGEX ]] && [ "$AIO_VERSION" != "$VERSION" ]; then
 		echo "Update version info in control file to '$AIO_VERSION'"
-		sed -i "s/\(Version: \)[0-9].[0-9].[0-9].[0-9]/\1$AIO_VERSION/" $control_pathfile
+		sed -i "s/\(Version: \)[0-9]\{1,\}.[0-9]\{1,\}.[0-9]\{1,\}.[0-9]\{1,\}/\1$AIO_VERSION/" $control_pathfile
 	fi
 }
 # Clone or update repository


### PR DESCRIPTION
Hi Thomas,

This PR contains changes to update debian `control` file due to `dev`|`rel` tag when building AIO package - Issue #118 .

Note: **the updated `control` file by this PR is only used for building package and is not committed back to Github.**
It means that the version information in control on Github will be not up-to-date without manual change.
_(I wonder that the commit for the version change of `control` file (when executing build pipeline) is required or not. 
Besides, the new commit for control file  will be also behind the release tag
=> In order to sync the version information of `control` file on Github, it should be be done before or during tagging for release.)_

Besides, I have also update somethings in pipeline ta adapt for `dev/aio/x.x.x.x` tag.

Please review and give your feeling about these changes.

Thank you,
Ngoan