### PR TITLE
Specific version pyGObject to avoid requiring glib >= 2.64.0

### DIFF
--- a/install/python_requirements_lx.txt
+++ b/install/python_requirements_lx.txt
@@ -147,7 +147,7 @@ odxtools
 xmlschema
 pyinstaller
 pycairo
-PyGObject
+PyGObject==3.44.1
 dasbus
 pre-commit
 pre-commit-hooks


### PR DESCRIPTION
Hi Thomas,

I have specified the version for PyGObject. Please help me merge this request.

Thank you, 
Thong Hua