### PR TITLE
Htv3hc/feat/trigger other workflow

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -16,7 +16,7 @@ on:
 
   repository_dispatch:
     types:
-      - Triggered by other workflow
+      - TRIGGER_AIO
 
 env:
   GITHUB_PAT : ${{ secrets.PAT_GITHUB }} 
@@ -48,7 +48,7 @@ jobs:
   trigger-aio:
     runs-on: ubuntu-latest
     name: Listen event trigger
-    if: github.event.action == 'Triggered from another workflow'
+    if: github.event.action == 'TRIGGER_AIO'
     outputs:
       repository: ${{ steps.extract_data.outputs.REPOSITORY }}
       branch: ${{ steps.extract_data.outputs.PULL_MERGE_BRANCH }}

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -68,7 +68,7 @@ jobs:
   build-linux:
     name: Build Linux package
     runs-on: ubuntu-latest
-    needs: tag-repos
+    needs: [ tag-repos , trigger-aio ]
     # if: always() && needs.tag-repos.result != 'failure' && needs.tag-repos.result != 'cancelled'
     if: ${{ ! failure() && ! cancelled() }}
 
@@ -113,7 +113,7 @@ jobs:
   build-windows:
     name: Build Windows package
     runs-on: windows-latest
-    needs: tag-repos
+    needs: [ tag-repos , trigger-aio ]
     if: ${{ ! failure() && ! cancelled() }}
 
     steps:

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -16,7 +16,7 @@ on:
 
   repository_dispatch:
     types:
-      - Triggered from another workflow
+      - Triggered by other workflow
 
 env:
   GITHUB_PAT : ${{ secrets.PAT_GITHUB }} 

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -8,9 +8,15 @@ on:
   pull_request:
     types:
       - closed
+      - opened
+      - synchronize
     branches: 
       - develop
   workflow_dispatch:
+
+  repository_dispatch:
+    types:
+      - Triggered from another workflow
 
 env:
   GITHUB_PAT : ${{ secrets.PAT_GITHUB }} 

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -45,6 +45,26 @@ jobs:
     - name: Tag repositories
       run: python ./tools/git-tag/git-tag.py "$TAG_NAME" ./config/repositories/tag_repos.json
 
+  trigger-aio:
+    runs-on: ubuntu-latest
+    name: Listen event trigger
+    if: github.event.action == 'Triggered from another workflow'
+    outputs:
+      repository: ${{ steps.extract_data.outputs.REPOSITORY }}
+      branch: ${{ steps.extract_data.outputs.PULL_MERGE_BRANCH }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Extract request data
+        id: extract_data
+        run: |
+          # Extract value from request JSON payload
+          repository=$(jq -r .client_payload.repository $GITHUB_EVENT_PATH)
+          branch=$(jq -r .client_payload.branch $GITHUB_EVENT_PATH)
+          echo "REPOSITORY=${repository#test-fullautomation/}"  >> "$GITHUB_OUTPUT"
+          echo "PULL_MERGE_BRANCH=$branch"  >> "$GITHUB_OUTPUT"
+
   build-linux:
     name: Build Linux package
     runs-on: ubuntu-latest
@@ -69,6 +89,8 @@ jobs:
 
       - name: Clone repositories
         run: |
+          REPOSITORY="${{needs.trigger-aio.outputs.repository}}"
+          PULL_REQUEST_BRANCH="${{needs.trigger-aio.outputs.branch}}"
           chmod +x ./cloneall
           ./cloneall
 

--- a/cloneall
+++ b/cloneall
@@ -137,8 +137,8 @@ fi
 # Receive event from other repos and update repository config file
 if [ -n "$REPOSITORY"  ] && [ -n "$PULL_REQUEST_BRANCH" ]; then 
 
-	sed -i "s/$REPOSITORY=\(.*\)/${REPOSITORY}=$PULL_REQUEST_BRANCH/" "$CONFIG_FILE"
-	echo "Updated $REPOSITORY in $CONFIG_FILE with value $PULL_REQUEST_BRANCH"
+	sed -i "s/$REPOSITORY=\(.*\)/${REPOSITORY}=$PULL_REQUEST_BRANCH/" "$config_file"
+	echo "Updated $REPOSITORY in $config_file with value $PULL_REQUEST_BRANCH"
 fi
 
 parse_config $config_file

--- a/cloneall
+++ b/cloneall
@@ -133,6 +133,14 @@ if [ -f $config_file ]; then
 else
 	errormsg "Repo configuration '$config_file' is not existing"
 fi
+
+# Receive event from other repos and update repository config file
+if [ -n "$REPOSITORY"  ] && [ -n "$PULL_REQUEST_BRANCH" ]; then 
+
+	sed -i "s/$REPOSITORY=\(.*\)/${REPOSITORY}=$PULL_REQUEST_BRANCH/" "$CONFIG_FILE"
+	echo "Updated $REPOSITORY in $CONFIG_FILE with value $PULL_REQUEST_BRANCH"
+fi
+
 parse_config $config_file
 
 goodmsg "Cloning repositories successfully done"


### PR DESCRIPTION
Hi Thomas,

I would like to update the code to resolve issue on https://github.com/test-fullautomation/RobotFramework_AIO/issues/137
* **Issues 1:** to trigger a pipeline when a new-pull-request, or updated-pull-request coming. We can use keyword **opened** and **synchronize**. 

**Note:** If we close a pull request, it also trigger pipeline as same as the process before.
```yaml
pull_request:
    types:
      - closed
      - opened
      - synchronize
```
* **Issues 2:** To trigger pipeline when a pull request come from other repositories.

The workflow of Robotframework_AIO following info below: 
1. I created a job named by **trigger-aio** to listen event from other repositories.
2.  That job will be worked following 2 use case:
* **Case 1:**  A new-pull-request, or updated-pull-request at this repos => Pipeline will be triggered without running **trigger-aio** jobs.
* **Case 2:**  A new-pul request, or updated-pull-request by other repostories => Pipliene will be triggered with running **trigger-aio** jobs. 
===>  After **trigger-aio** it will get info from other repository such as REPOSITORY NAME and BRANCH NAME. It will replace the value in **repositories.conf** to make this RobotFramework_AIO clone other repositories with the target branch of pull request .
===> Then it will combine all code for building.

Could you help me review my pull-request? 

Thank you and best regards,
Thong Hua
