### PR TITLE
avoid to install log files with Windows installer

### DIFF
--- a/scripts/RobotFrameworkSetup.iss
+++ b/scripts/RobotFrameworkSetup.iss
@@ -104,7 +104,7 @@ Source: "R:\python39\*"; Excludes: ".git,*.pyc"; DestDir: {app}\python39; Flags:
 Source: "R:\robotframework-selftest\*"; Excludes: ".git"; DestDir: {app}\selftest; Flags: ignoreversion recursesubdirs createallsubdirs; Permissions: everyone-full;
 
 ;Visual Studio Code installation
-Source: "R:\robotvscode\*"; Excludes: ".git"; DestDir: {app}\robotvscode; Flags: ignoreversion recursesubdirs createallsubdirs; Permissions: everyone-full;
+Source: "R:\robotvscode\*"; Excludes: ".git,logs"; DestDir: {app}\robotvscode; Flags: ignoreversion recursesubdirs createallsubdirs; Permissions: everyone-full;
 
 ;tools installation
 Source: "..\config\tools\*"; Excludes: ".git,*.pyc"; DestDir: {app}\tools; Flags: ignoreversion recursesubdirs createallsubdirs; Permissions: everyone-full;


### PR DESCRIPTION
Hi Thomas,

This PR fixes issue #155 .
The `logs` folder under robotvscode is excluded when building Windows installer file.

Thank you,
Ngoan