### PR TITLE
Htv3hc/feat/update default type terminal vs codium

### DIFF
--- a/config/robotvscode/data/user-data/User/settings.json
+++ b/config/robotvscode/data/user-data/User/settings.json
@@ -50,6 +50,7 @@
     },
     "diffEditor.ignoreTrimWhitespace": false,
     "terminal.integrated.defaultProfile.windows": "PowerShell",
+    "terminal.integrated.defaultProfile.linux": "Git Bash",
     "editor.suggestSelection": "first",
     "files.exclude": {
         "**/.classpath": true,

--- a/config/robotvscode/data/user-data/User/settings.json
+++ b/config/robotvscode/data/user-data/User/settings.json
@@ -49,7 +49,7 @@
         "*.ipynb": "jupyter-notebook"
     },
     "diffEditor.ignoreTrimWhitespace": false,
-    "terminal.integrated.defaultProfile.windows": "Git Bash",
+    "terminal.integrated.defaultProfile.windows": "PowerShell",
     "editor.suggestSelection": "first",
     "files.exclude": {
         "**/.classpath": true,


### PR DESCRIPTION
Hi Thomas,

I have updated the default type of integrated terminal in VSCodium on both Windows and Linux platforms at ticket https://github.com/test-fullautomation/RobotFramework_AIO/issues/164.
The user can modify it to customize the terminal on their local machine.

Thank you, 
Thong Hua