### PR TITLE
Valid variable environment on Test jobs

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -160,7 +160,7 @@ jobs:
   install-test-windows:
     name: Test Windows package
     runs-on: windows-latest
-    needs: build-windows
+    needs: [ build-windows  , trigger-aio ]
     if: ${{ ! failure() && ! cancelled() }}
     env:
       RobotPythonPath: "C:/Program Files/RobotFramework/python39"
@@ -218,7 +218,7 @@ jobs:
   install-test-linux:
     name: Test Linux package
     runs-on: ubuntu-latest
-    needs: build-linux
+    needs: [ build-linux , trigger-aio ]
     if: ${{ ! failure() && ! cancelled() }}
 
     steps:


### PR DESCRIPTION
Hi Thomas,

I would like to update this code https://github.com/test-fullautomation/RobotFramework_AIO/issues/137 to valid the variable environment when other repositories trigger AIO pipeline . It will synchronize the trigger branch for cloning all repositories. 
It will fix the error at pipeline https://github.com/test-fullautomation/RobotFramework_AIO/actions/runs/7027540407/job/19122455176
Please you have any concerns, please tell me.

Thank you,
Thong Hua
