### PR TITLE
Generate release info file and upload to asset.

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -205,7 +205,7 @@ jobs:
     - name: Generate release info
       shell: powershell
       run: |
-        & $env:RobotPythonPath\python .\tools\release_info\release_info.py --configfile ".\example\release_info_config_ReleaseToolTest.json"
+        & $env:RobotPythonPath\python .\tools\release_info\release_info.py --configfile ".\release_info_config_OSS.json"
         mv .\tools\release_info\example\release_info_RobotFramework_AIO_*.html ..\ 
 
          
@@ -266,8 +266,7 @@ jobs:
     - name: Generate release info
       run: |
         . /opt/rfwaio/linux/set_robotenv.sh
-        $RobotPythonPath/python3.9 tools/release_info/release_info.py --configfile ./example/release_info_config_ReleaseToolTest.json
-        ls -la ./tools/release_info
+        $RobotPythonPath/python3.9 tools/release_info/release_info.py --configfile ./release_info_config_OSS.json
         mv ./tools/release_info/example/release_info_RobotFramework_AIO_*.html ../
        
     - name: Upload test result as artifact
@@ -296,7 +295,7 @@ jobs:
       run: |
         echo "EXE_FILE=$(ls windows-package/*.exe | head -1)" >> $GITHUB_ENV
         echo "DEB_FILE=$(ls linux-package/*.deb | head -1)" >> $GITHUB_ENV
-        echo "RELEASE_INFO_FILE=$(ls linux-aiotestlogfiles/*.html | head -1)" >> $GITHUB_ENV
+        echo "RELEASE_INFO_FILE=$(ls windows-aiotestlogfiles/*.html | head -1)" >> $GITHUB_ENV
         echo "RELEASE_VERSION=${TAG_NAME#rel/aio/}" >> $GITHUB_ENV
 
     - name: Create Release
@@ -337,7 +336,7 @@ jobs:
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ${{ env.RELEASE_INFO_FILE }}
-        asset_name: RELEASE_INFO_FILE
+        asset_name: release_info_RobotFramework_AIO_${{ env.RELEASE_VERSION }}.html
         asset_content_type: text/html
 
   tag-to-publish-packges-to-pypi:

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -195,6 +195,7 @@ jobs:
       shell: bash
       run: |
         "$RobotPythonPath/python" test/aio-test-trigger/aio-test-trigger.py 2>&1 | tee console_log.txt
+        mv console_log.txt ../
         # Get system error code from python program
         exit_code=${PIPESTATUS[0]}
         if [ $exit_code -ne 0 ]; then
@@ -205,7 +206,8 @@ jobs:
       shell: powershell
       run: |
         & $env:RobotPythonPath\python .\tools\release_info\release_info.py --configfile ".\example\release_info_config_ReleaseToolTest.json"
-        dir .\tools\release_info\
+        mv .\tools\release_info\example\release_info_RobotFramework_AIO_*.html ..\ 
+
          
     - name: Upload test result as artifact
       if: success() || failure()
@@ -219,8 +221,8 @@ jobs:
           ${{ runner.workspace }}/[Pp]ython*/**/*/aiotestlogfiles/*
           ${{ runner.workspace }}/[Rr]obotframework*/**/*/testlogfiles/*
           ${{ runner.workspace }}/[Pp]ython*/**/*/testlogfiles/*
-          ${{ runner.workspace }}/Robotframework_AIO/console_log.txt
-          ${{ runner.workspace }}/Robotframework_AIO/tools/release_info/release_info_RobotFramework_AIO_*.html
+          ${{ runner.workspace }}/console_log.txt
+          ${{ runner.workspace }}/release_info_RobotFramework_AIO_*.html
 
 
   install-test-linux:
@@ -254,6 +256,7 @@ jobs:
       run: |
         . /opt/rfwaio/linux/set_robotenv.sh
         $RobotPythonPath/python3.9 test/aio-test-trigger/aio-test-trigger.py 2>&1 | tee console_log.txt
+        mv console_log.txt ../
         # Get system error code from python program
         exit_code=${PIPESTATUS[0]}
         if [ $exit_code -ne 0 ]; then
@@ -265,6 +268,7 @@ jobs:
         . /opt/rfwaio/linux/set_robotenv.sh
         $RobotPythonPath/python3.9 tools/release_info/release_info.py --configfile ./example/release_info_config_ReleaseToolTest.json
         ls -la ./tools/release_info
+        mv ./tools/release_info/example/release_info_RobotFramework_AIO_*.html ../
        
     - name: Upload test result as artifact
       if: success() || failure()
@@ -274,8 +278,8 @@ jobs:
         path: |
           ${{ runner.workspace }}/**/*/aiotestlogfiles/*
           ${{ runner.workspace }}/**/*/testlogfiles/*
-          ${{ runner.workspace }}/**/*/console_log.txt
-          ${{ runner.workspace }}/tools/release_info/release_info_RobotFramework_AIO_*.html
+          ${{ runner.workspace }}/console_log.txt
+          ${{ runner.workspace }}/release_info_RobotFramework_AIO_*.html
 
 
   release:

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -262,6 +262,7 @@ jobs:
 
     - name: Generate release info
       run: |
+        . /opt/rfwaio/linux/set_robotenv.sh
         $RobotPythonPath/python3.9 tools/release_info/release_info.py --configfile ./example/release_info_config_ReleaseToolTest.json
         ls -la ./tools/release_info
        

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -203,10 +203,10 @@ jobs:
         fi
 
     - name: Generate release info
-      shell: powershell
+      shell: cmd
       run: |
-        & $env:RobotPythonPath\python .\tools\release_info\release_info.py --configfile ".\release_info_config_OSS.json"
-        mv .\tools\release_info\example\release_info_RobotFramework_AIO_*.html ..\ 
+        "%RobotPythonPath%\python" .\tools\release_info\release_info.py --configfile ".\release_info_config_OSS.json"
+        mv .\tools\release_info\release_info_RobotFramework_AIO_*.html ..\ 
 
          
     - name: Upload test result as artifact
@@ -267,7 +267,7 @@ jobs:
       run: |
         . /opt/rfwaio/linux/set_robotenv.sh
         $RobotPythonPath/python3.9 tools/release_info/release_info.py --configfile ./release_info_config_OSS.json
-        mv ./tools/release_info/example/release_info_RobotFramework_AIO_*.html ../
+        mv ./tools/release_info/release_info_RobotFramework_AIO_*.html ../
        
     - name: Upload test result as artifact
       if: success() || failure()

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -201,6 +201,12 @@ jobs:
             exit 1
         fi
 
+    - name: Generate release info
+      shell: powershell
+      run: |
+        & $env:RobotPythonPath\python .\tools\release_info\release_info.py --configfile ".\example\release_info_config_ReleaseToolTest.json"
+        dir .\tools\release_info\
+         
     - name: Upload test result as artifact
       if: success() || failure()
       uses: actions/upload-artifact@v3
@@ -214,6 +220,8 @@ jobs:
           ${{ runner.workspace }}/[Rr]obotframework*/**/*/testlogfiles/*
           ${{ runner.workspace }}/[Pp]ython*/**/*/testlogfiles/*
           ${{ runner.workspace }}/Robotframework_AIO/console_log.txt
+          ${{ runner.workspace }}/Robotframework_AIO/tools/release_info/release_info_RobotFramework_AIO_*.html
+
 
   install-test-linux:
     name: Test Linux package
@@ -252,7 +260,11 @@ jobs:
             exit 1
         fi
 
-
+    - name: Generate release info
+      run: |
+        $RobotPythonPath/python3.9 tools/release_info/release_info.py --configfile ./example/release_info_config_ReleaseToolTest.json
+        ls -la ./tools/release_info
+       
     - name: Upload test result as artifact
       if: success() || failure()
       uses: actions/upload-artifact@v3
@@ -262,6 +274,7 @@ jobs:
           ${{ runner.workspace }}/**/*/aiotestlogfiles/*
           ${{ runner.workspace }}/**/*/testlogfiles/*
           ${{ runner.workspace }}/**/*/console_log.txt
+          ${{ runner.workspace }}/tools/release_info/release_info_RobotFramework_AIO_*.html
 
 
   release:
@@ -278,6 +291,7 @@ jobs:
       run: |
         echo "EXE_FILE=$(ls windows-package/*.exe | head -1)" >> $GITHUB_ENV
         echo "DEB_FILE=$(ls linux-package/*.deb | head -1)" >> $GITHUB_ENV
+        echo "RELEASE_INFO_FILE=$(ls linux-aiotestlogfiles/*.html | head -1)" >> $GITHUB_ENV
         echo "RELEASE_VERSION=${TAG_NAME#rel/aio/}" >> $GITHUB_ENV
 
     - name: Create Release
@@ -310,6 +324,16 @@ jobs:
         asset_path: ${{ env.DEB_FILE }}
         asset_name: setup_RobotFramework_AIO_Linux_${{ env.RELEASE_VERSION }}.deb
         asset_content_type: application/vnd.debian.binary-package
+    
+    - name: Upload Release Info Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ env.RELEASE_INFO_FILE }}
+        asset_name: RELEASE_INFO_FILE
+        asset_content_type: text/html
 
   tag-to-publish-packges-to-pypi:
     name: Tag Python packages to trigger workflow for publishing to PyPI

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -165,6 +165,7 @@ jobs:
     env:
       RobotPythonPath: "C:/Program Files/RobotFramework/python39"
       RobotTutorialPath: "C:/RobotTest/tutorial"
+      RobotPythonSitePackagesPath: "C:/Program Files/RobotFramework/python39/Lib/site-packages"
       GENDOC_PLANTUML_PATH: "C:/Program Files/RobotFramework/robotvscode/data/extensions/jebbs.plantuml-2.17.5"
 
     steps:

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -207,7 +207,7 @@ jobs:
       shell: cmd
       run: |
         "%RobotPythonPath%\python" .\tools\release_info\release_info.py --configfile ".\release_info_config_OSS.json"
-        mv .\tools\release_info\release_info_RobotFramework_AIO_*.html ..\ 
+        move .\tools\release_info\release_info_RobotFramework_AIO_*.html ..\
 
          
     - name: Upload test result as artifact

--- a/config/repositories/publish_pypi_repos.txt
+++ b/config/repositories/publish_pypi_repos.txt
@@ -9,3 +9,4 @@ robotframework-robotlog2db
 robotframework-robotlog2rqm
 robotframework-dbus
 robotframework-qconnect-winapp
+robotframework-doip

--- a/config/repositories/publish_pypi_repos.txt
+++ b/config/repositories/publish_pypi_repos.txt
@@ -9,4 +9,3 @@ robotframework-robotlog2db
 robotframework-robotlog2rqm
 robotframework-dbus
 robotframework-qconnect-winapp
-robotframework-doip

--- a/config/repositories/repositories.conf
+++ b/config/repositories/repositories.conf
@@ -16,6 +16,7 @@ robotframework-tutorial=
 robotframework-robotlog2rqm=
 robotframework-robotlog2db=
 robotframework-documentation=
+robotframework-doip=
 robotframework=develop_6.1
 
 testresultwebapp=


### PR DESCRIPTION
Hi Thomas,

I would like to update the code for generating release info file.
Currently, whenever we trigger for release, it will upload the release info file to our asset. Beside that, the release info also put to the logger folder for debugging in the future. 
Please help me review this pull request, if you have any concerns, please tell me.

Thank you and best regards,
Thong Hua