### PR TITLE
Fix issue related to logger on Linux.

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -196,7 +196,6 @@ jobs:
       shell: bash
       run: |
         "$RobotPythonPath/python" test/aio-test-trigger/aio-test-trigger.py 2>&1 | tee console_log.txt
-        mv console_log.txt ../
         # Get system error code from python program
         exit_code=${PIPESTATUS[0]}
         if [ $exit_code -ne 0 ]; then
@@ -222,7 +221,7 @@ jobs:
           ${{ runner.workspace }}/[Pp]ython*/**/*/aiotestlogfiles/*
           ${{ runner.workspace }}/[Rr]obotframework*/**/*/testlogfiles/*
           ${{ runner.workspace }}/[Pp]ython*/**/*/testlogfiles/*
-          ${{ runner.workspace }}/console_log.txt
+          ${{ runner.workspace }}/Robotframework_AIO/console_log.txt
           ${{ runner.workspace }}/release_info_RobotFramework_AIO_*.html
 
 
@@ -257,7 +256,6 @@ jobs:
       run: |
         . /opt/rfwaio/linux/set_robotenv.sh
         $RobotPythonPath/python3.9 test/aio-test-trigger/aio-test-trigger.py 2>&1 | tee console_log.txt
-        mv console_log.txt ../
         # Get system error code from python program
         exit_code=${PIPESTATUS[0]}
         if [ $exit_code -ne 0 ]; then
@@ -278,7 +276,7 @@ jobs:
         path: |
           ${{ runner.workspace }}/**/*/aiotestlogfiles/*
           ${{ runner.workspace }}/**/*/testlogfiles/*
-          ${{ runner.workspace }}/console_log.txt
+          ${{ runner.workspace }}/**/*/console_log.txt
           ${{ runner.workspace }}/release_info_RobotFramework_AIO_*.html
 
 


### PR DESCRIPTION
Hi Thomas,

- As the result occurred in https://github.com/test-fullautomation/RobotFramework_AIO/actions/runs/7556128679
- The error occurred in the Windows testing, but did not happen in Linux testing because the pipeline can't catch the error code in Linux platform after merging the request https://github.com/test-fullautomation/python-jsonpreprocessor/pull/196
- Therefore, I would like to update the code to address this issue, and the current result will fail in both Linux and Windows platforms.

Could you help me merge this request?

Thank you and best regards,
Thong Hua