### PR TITLE
Ntd1hc/bug/test job still run although installation failed

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -223,6 +223,7 @@ jobs:
           ${{ runner.workspace }}/[Pp]ython*/**/*/testlogfiles/*
           ${{ runner.workspace }}/Robotframework_AIO/console_log.txt
           ${{ runner.workspace }}/release_info_RobotFramework_AIO_*.html
+          ${{ runner.workspace }}/Robotframework_AIO/install-windows.log
 
 
   install-test-linux:

--- a/requirements_linux.sh
+++ b/requirements_linux.sh
@@ -18,3 +18,4 @@ sudo apt-get install -y build-essential
 sudo apt-get install -y pandoc
 sudo apt-get install -y texlive-latex-*
 sudo apt-get install -y libcairo2-dev libxt-dev libgirepository1.0-dev
+sudo apt-get install -y dos2unix

--- a/scripts/install-windows.bat
+++ b/scripts/install-windows.bat
@@ -18,6 +18,7 @@ for /f "tokens=*" %%a in ('dir /b !directory!\*.exe') do (
             echo !app! installation successful.
         ) else (
             echo !app! installation failed.
+            exit 1
         )
     )
 )


### PR DESCRIPTION
Hi Thomas,

This PR adds the exit code when failed to install Robotframework AIO and store the installation log as artifact.
Besides, I also added dependency package for Linux `dos2unix`  (currently missing on OSD7 runner). which is used to collect log in Gitlab

Thank you,
Ngoan