### PR TITLE
Ntd1hc/feat/211 multiple corrupted unins00x files is still in app folder

### DIFF
--- a/scripts/RobotFrameworkSetup.iss
+++ b/scripts/RobotFrameworkSetup.iss
@@ -647,4 +647,4 @@ Name: {app}\tools\*; Type: filesandordirs;
 Name: {app}\selftest\*; Type: filesandordirs;
 ;Name: {app}\devtools\*; Type: filesandordirs;
 Name: {code:GetUsrDataDir}\documentation; Type: filesandordirs;
-
+Type: files; Name: "{app}\unins00*.*"; Check: ShouldRemoveUninsFiles(ExpandConstant('{app}'))


### PR DESCRIPTION
Hi Thomas,

This PR add step to detect corrupted `unins00*.dat` files then remove them (include corresponding `unins00*.exe`) during installation or uninstallation.

Thank you,
Ngoan