### PR TITLE
Assign a key to combine the execution of Python scripts is "Run Python File in Terminal"

### DIFF
--- a/config/robotframework_aio/release_items_Robotframework_AIO.json
+++ b/config/robotframework_aio/release_items_Robotframework_AIO.json
@@ -63,6 +63,14 @@
 * Integrated **robotframework-doip** library
 * Integrated **doipclient** library
 "
-                             ]
+                             ],
+                   "0.11." : [
+"
+**VSCodium**
+
+* Assigning the keyboard shortcut **CTRL+F6** for executing the **Run Python File in Terminal** feature. With this update, users can quickly run Python programs in the terminal by pressing **CTRL+F6**.
+
+"
+                              ]
                  }
 }

--- a/scripts/PowerShell/update_vsdata.ps1
+++ b/scripts/PowerShell/update_vsdata.ps1
@@ -32,6 +32,10 @@ $KeyBindingContent = '
     {
         "key": "ctrl+alt+r",
         "command": "vs-external-tools.externalCommand1"
+    },
+    {
+        "key": "ctrl+f6",
+        "command": "python.execInTerminal"
     }
 ]'
 


### PR DESCRIPTION
Hi Thomas,
Cc Holger

As Holger mentioned in ticket https://github.com/test-fullautomation/RobotFramework_AIO/issues/225.
I have checked that the key combination **CTRL+F6**  is not yet assigned to any other function. Therefore, I have bound it to function "Run Python File in Terminal". 

If you have any concerns, please let me know.

Thank you and best regards,
Thong Hua