### PR TITLE
fix long path issue when building on Windows Gitlab runner

### DIFF
--- a/config/tools/Appium.bat
+++ b/config/tools/Appium.bat
@@ -6,6 +6,6 @@ set path=%path%;
 set ANDROID_HOME=%RobotDevtools%\Android
 set APPIUM_HOME=%RobotNodeJS%
 
-start "Appium" "%RobotAppium%"\appium
+start "Appium" "%RobotAppium%\appium"
 
 @echo on

--- a/scripts/RobotFrameworkSetup.iss
+++ b/scripts/RobotFrameworkSetup.iss
@@ -114,9 +114,9 @@ Source: "..\config\tools\*"; Excludes: ".git,*.pyc"; DestDir: {app}\tools; Flags
 Source: "..\test\aio-analyzer\*"; Excludes: ".git,*.pyc"; DestDir: {app}\tools\aio-analyzer; Flags: ignoreversion recursesubdirs createallsubdirs; Permissions: everyone-full;
 
 ;Android related
-Source: "..\..\devtools\Android\*"; Excludes: ".git"; DestDir: {app}\devtools\Android; Flags: ignoreversion recursesubdirs createallsubdirs onlyifdoesntexist uninsneveruninstall; Permissions: users-full; Components: "Android"
-Source: "..\..\devtools\nodejs\*"; Excludes: ".git"; DestDir: {app}\devtools\nodejs; Flags: ignoreversion recursesubdirs createallsubdirs onlyifdoesntexist uninsneveruninstall; Permissions: users-full; Components: "Android"
-Source: "..\..\devtools\Appium-Inspector\*"; Excludes: ".git"; DestDir: {app}\devtools\Appium-Inspector; Flags: ignoreversion recursesubdirs createallsubdirs onlyifdoesntexist uninsneveruninstall; Permissions: users-full; Components: "Android"
+Source: "R:\devtools\Android\*"; Excludes: ".git"; DestDir: {app}\devtools\Android; Flags: ignoreversion recursesubdirs createallsubdirs onlyifdoesntexist uninsneveruninstall; Permissions: users-full; Components: "Android"
+Source: "R:\devtools\nodejs\*"; Excludes: ".git"; DestDir: {app}\devtools\nodejs; Flags: ignoreversion recursesubdirs createallsubdirs onlyifdoesntexist uninsneveruninstall; Permissions: users-full; Components: "Android"
+Source: "R:\devtools\Appium-Inspector\*"; Excludes: ".git"; DestDir: {app}\devtools\Appium-Inspector; Flags: ignoreversion recursesubdirs createallsubdirs onlyifdoesntexist uninsneveruninstall; Permissions: users-full; Components: "Android"
 Source: "..\config\tools\Appium.bat"; Excludes: ".git"; DestDir: {app}\devtools; Flags: ignoreversion uninsneveruninstall; Permissions: users-full; Components: "Android"
 
 #include '..\include\windows\install_projects.iss';


### PR DESCRIPTION
Hi Thomas,

This PR fixes current issue on Windows Gitlab Runner due to long path of android/nodejs packages.

Thank you,
Ngoan