### PR TITLE
fix issue when install appium in BIOS's runners

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -240,18 +240,26 @@ function packaging_android() {
 	else
 	   mkdir $destDir/devtools/nodejs
 		tar -xf ${sourceDir}/${archived_nodejs} -C $destDir/devtools/nodejs --strip-components=1
+		PATH="$destDir/devtools/nodejs/bin:$PATH"
 		npm_bin=$destDir/devtools/nodejs/bin/npm
+	fi
+
+	npm_proxy_args=""
+	if [ "$use_cntlm" == "Yes" ]; then
+		npm_proxy_args="--proxy=http://localhost:3128"
 	fi
 
 	# download appium packages:
 	# 	- appium server 
 	echo "Installing appium server"
-	$npm_bin install --prefix $destDir/devtools/nodejs appium -g
+	$npm_bin install --prefix $destDir/devtools/nodejs appium -g ${npm_proxy_args}
+	logresult "$?" "installed appium server" "install appium server"
 
 	#  - UIAutomator2 driver for appium
 	echo "Installing UIAutomator2 driver for appium"
 	export APPIUM_SKIP_CHROMEDRIVER_INSTALL=1
-	$npm_bin install --prefix $destDir/devtools/nodejs appium-uiautomator2-driver -g
+	$npm_bin install --prefix $destDir/devtools/nodejs appium-uiautomator2-driver -g ${npm_proxy_args}
+	logresult "$?" "installed UIAutomator2 driver for appium" "install UIAutomator2 driver for appium"
 	# APPIUM_HOME=./android appium driver install uiautomator2
 	# APPIUM_HOME=./android appium => scan appium drivers under APPIUM_HOME
 


### PR DESCRIPTION
Hi Thomas,

With `dev/0.11.0.4` build, I found that BIOS Linux runners face issue when installing Appium and its driver due to proxy.
This PR fix this issue.

No impact for OSS and BIOS Windows Runners.

Thank you,
Ngoan