### PR TITLE
Ntd1hc/feat/296 debian package postinstall not sufficient in non root docker environment

### DIFF
--- a/build
+++ b/build
@@ -326,10 +326,12 @@ function build_debian()
 	# Vscodium package and RobotTest workspace
 	cp -R -a ../robotvscode/. ./output_lx/${PACK_NAME}/opt/rfwaio/robotvscode
 	cp -R -a ./config/RobotTest/. ./output_lx/${PACK_NAME}/opt/rfwaio/robotvscode/RobotTest
-	mkdir -p ./output_lx/${PACK_NAME}/opt/rfwaio/robotvscode/RobotTest/tutorial
-	cp -R -a ../robotframework-tutorial/[0-9][0-9][0-9]_* ./output_lx/${PACK_NAME}/opt/rfwaio/robotvscode/RobotTest/tutorial/
-	mkdir -p ./output_lx/${PACK_NAME}/opt/rfwaio/robotvscode/RobotTest/documentation
-	cp ../robotframework-documentation/book/RobotFrameworkAIO_Reference.pdf ./output_lx/${PACK_NAME}/opt/rfwaio/robotvscode/RobotTest/documentation/
+
+	# Tutorial and Documentation packages
+	mkdir -p ./output_lx/${PACK_NAME}/opt/rfwaio/tutorial
+	cp -R -a ../robotframework-tutorial/[0-9][0-9][0-9]_* ./output_lx/${PACK_NAME}/opt/rfwaio/tutorial/
+	mkdir -p ./output_lx/${PACK_NAME}/opt/rfwaio/documentation
+	cp ../robotframework-documentation/book/RobotFrameworkAIO_Reference.pdf ./output_lx/${PACK_NAME}/opt/rfwaio/documentation/
 
 	# Python package: core framework and libraries
 	cp -R -a ../python39lx/. ./output_lx/${PACK_NAME}/opt/rfwaio/python39

--- a/build
+++ b/build
@@ -342,6 +342,7 @@ function build_debian()
 
 	# initial script to setup environment for multiple users
 	cp ./config/build/dpkg_build/postinst.sh ./output_lx/${PACK_NAME}/usr/local/bin/initRobotFrameworkAIO.sh
+	chmod +x ./output_lx/${PACK_NAME}/usr/local/bin/initRobotFrameworkAIO.sh
 
 	# Update version
 	cp ./version.txt ./output_lx/${PACK_NAME}/opt/rfwaio/

--- a/build
+++ b/build
@@ -339,6 +339,8 @@ function build_debian()
 	mkdir -p ./output_lx/${PACK_NAME}/opt/rfwaio/devtools
 	cp -R -a ../devtools/. ./output_lx/${PACK_NAME}/opt/rfwaio/devtools
 	chmod +x ./output_lx/${PACK_NAME}/opt/rfwaio/devtools/Appium-Inspector.AppImage
+	cp ./config/tools/appium.sh ./output_lx/${PACK_NAME}/opt/rfwaio/devtools/appium
+	chmod +x ./output_lx/${PACK_NAME}/opt/rfwaio/devtools/appium
 
 	# initial script to setup environment for multiple users
 	cp ./config/build/dpkg_build/postinst.sh ./output_lx/${PACK_NAME}/usr/local/bin/initRobotFrameworkAIO.sh

--- a/config/build/dpkg_build/appium.desktop
+++ b/config/build/dpkg_build/appium.desktop
@@ -2,6 +2,6 @@
 Comment=Start Appium Server
 Terminal=true
 Name=Appium Server
-Exec=bash -c 'export ANDROID_HOME=/opt/rfwaio/devtools/Android; export APPIUM_HOME=/opt/rfwaio/devtools/nodejs/lib; /opt/rfwaio/devtools/nodejs/bin/appium'
+Exec=/opt/rfwaio/devtools/appium
 Type=Application
 Icon=/opt/rfwaio/linux/icon/appium.png

--- a/config/build/dpkg_build/postinst.sh
+++ b/config/build/dpkg_build/postinst.sh
@@ -151,7 +151,7 @@ else
    fi
 fi
 
-   
+
 # Set schedule for installing DLTConnector (will active in future)
 #
 ############################################################################### 
@@ -176,9 +176,11 @@ if [ ! -d "${HOME}/RobotTest" ]; then
    # Create RobotTest Workspacce Folder
    #
    ##############################################################################
-   cp -R -a /opt/rfwaio/robotvscode/RobotTest/testcases/. ${HOME}/RobotTest/testcases
-   cp -R -a /opt/rfwaio/robotvscode/RobotTest/tutorial/. ${HOME}/RobotTest/tutorial
-   cp -R -a /opt/rfwaio/robotvscode/RobotTest/documentation/. ${HOME}/RobotTest/documentation
+   if [ -d "/opt/rfwaio/robotvscode" ]; then
+      cp -R -a /opt/rfwaio/robotvscode/RobotTest/testcases/. ${HOME}/RobotTest/testcases
+   fi
+   cp -R -a /opt/rfwaio/tutorial/. ${HOME}/RobotTest/tutorial
+   cp -R -a /opt/rfwaio/documentation/. ${HOME}/RobotTest/documentation
 
    echo -e "${MSG_DONE} Creating initial workspace in ~/RobotTest"
 else
@@ -195,7 +197,7 @@ else
       mkdir -p ${HOME}/RobotTest/tutorial
       action_msg="Created"
    fi
-   cp -R -a /opt/rfwaio/robotvscode/RobotTest/tutorial/. ${HOME}/RobotTest/tutorial
+   cp -R -a /opt/rfwaio/tutorial/. ${HOME}/RobotTest/tutorial
    update_owner ${HOME}/RobotTest/tutorial
    echo -e "${MSG_DONE} ${action_msg} tutorial folder."
 
@@ -206,7 +208,7 @@ else
       mkdir -p ${HOME}/RobotTest/documentation
       action_msg="Created"
    fi
-   cp -R -a /opt/rfwaio/robotvscode/RobotTest/documentation/. ${HOME}/RobotTest/documentation
+   cp -R -a /opt/rfwaio/documentation/. ${HOME}/RobotTest/documentation
    echo -e "${MSG_DONE} ${action_msg} documentation folder."
 
    if [ ! -d ${HOME}/RobotTest/testcases ]; then
@@ -224,11 +226,11 @@ if [ -e "${APPS_PATH}" ]; then
    # remove it in case it is fine then create appropriate directory 
    if [ -f "${APPS_PATH}" ]; then
       rm "${APPS_PATH}"
-      mkdir "${APPS_PATH}"
+      mkdir -p "${APPS_PATH}"
    fi
 else
    # Create applications launcher folder if not existing
-   mkdir "${APPS_PATH}"
+   mkdir -p "${APPS_PATH}"
 fi
 
 # Check whether this script is executed in installation or not

--- a/config/build/dpkg_build/postinst.sh
+++ b/config/build/dpkg_build/postinst.sh
@@ -2,8 +2,8 @@
 # Script to setup enviroment for Robotframework AIO on Linux
 # This should run 1 time when postinst
 
-   # This owner change is required when installation with sudo permission
-   # File/Folder after copying need to change the owner to actual user instead of root
+# This owner change is required when installation with sudo permission
+# File/Folder after copying need to change the owner to actual user instead of root
 function update_owner(){
    if [ "$(id -u)" = "0" ]; then
       chown -R "${CURRENT_USER}:${sGROUP}" $1
@@ -209,6 +209,7 @@ else
       action_msg="Created"
    fi
    cp -R -a /opt/rfwaio/documentation/. ${HOME}/RobotTest/documentation
+   update_owner ${HOME}/RobotTest/documentation
    echo -e "${MSG_DONE} ${action_msg} documentation folder."
 
    if [ ! -d ${HOME}/RobotTest/testcases ]; then
@@ -256,14 +257,10 @@ if [ -f "${SELECTED_CMPTS_FILE}" ];then
       #
       #############################################################################
       allow_user_group_permissions /opt/rfwaio/robotvscode/data
+      allow_user_group_permissions /opt/rfwaio/robotvscode/RobotTest
       update_vscodium_related;
    fi
-
-   #
-   # Update permission of Vscodium-related data
-   #
-   #############################################################################
-   allow_user_group_permissions /opt/rfwaio/robotvscode/RobotTest
+   
 
    rm ${SELECTED_CMPTS_FILE}
 else

--- a/config/build/dpkg_build/postinst.sh
+++ b/config/build/dpkg_build/postinst.sh
@@ -102,6 +102,16 @@ function update_vscodium_related(){
 echo "Creating/Updating RobotFramework AIO runtime environment"
 echo "----------------------------------------"
 
+COL_GREEN='\033[0;32m'
+COL_ORANGE='\033[0;33m'
+COL_BLUE='\033[0;34m'
+COL_RED='\033[1;31m'
+COL_RESET='\033[0m' # No Color
+
+MSG_INFO="${COL_GREEN}[INFO]${COL_RESET}"
+MSG_DONE="${COL_ORANGE}[DONE]${COL_RESET}"
+MSG_ERR="${COL_RED}[ERR]${COL_RESET} "
+
 CURRENT_USER=${SUDO_USER}
 if [ -z ${CURRENT_USER} ]; then
    CURRENT_USER=$(whoami)
@@ -141,15 +151,6 @@ else
    fi
 fi
 
-COL_GREEN='\033[0;32m'
-COL_ORANGE='\033[0;33m'
-COL_BLUE='\033[0;34m'
-COL_RED='\033[1;31m'
-COL_RESET='\033[0m' # No Color
-
-MSG_INFO="${COL_GREEN}[INFO]${COL_RESET}"
-MSG_DONE="${COL_ORANGE}[DONE]${COL_RESET}"
-MSG_ERR="${COL_RED}[ERR]${COL_RESET} "
    
 # Set schedule for installing DLTConnector (will active in future)
 #
@@ -178,12 +179,7 @@ if [ ! -d "${HOME}/RobotTest" ]; then
    cp -R -a /opt/rfwaio/robotvscode/RobotTest/testcases/. ${HOME}/RobotTest/testcases
    cp -R -a /opt/rfwaio/robotvscode/RobotTest/tutorial/. ${HOME}/RobotTest/tutorial
    cp -R -a /opt/rfwaio/robotvscode/RobotTest/documentation/. ${HOME}/RobotTest/documentation
-   
-   #
-   # assure access rights to files in ~/ROBFW
-   #
-   ###############################################################################                          
-   allow_user_group_permissions ${HOME}/RobotTest
+
    echo -e "${MSG_DONE} Creating initial workspace in ~/RobotTest"
 else
    #
@@ -260,6 +256,12 @@ if [ -f "${SELECTED_CMPTS_FILE}" ];then
       allow_user_group_permissions /opt/rfwaio/robotvscode/data
       update_vscodium_related;
    fi
+
+   #
+   # Update permission of Vscodium-related data
+   #
+   #############################################################################
+   allow_user_group_permissions /opt/rfwaio/robotvscode/RobotTest
 
    rm ${SELECTED_CMPTS_FILE}
 else

--- a/config/robotframework_aio/release_items_Robotframework_AIO.json
+++ b/config/robotframework_aio/release_items_Robotframework_AIO.json
@@ -170,7 +170,41 @@
 
 * Publish Robotframework-prometheus package to `PyPI <https://pypi.org/user/ThPoll>`_
 
+**Environment/Installation**
 
+* Debian package:
+
+  * Enhanced **initRobotFrameworkAIO.sh**, support to setup environment for non-root user
+
+  * Introduce new user group **robot-aio** which is granted required permissions to use *robotframework-aio* package
+
+    An user (BOT or integrator account) which have non-root permission can also be setup to use the installed robotframework-aio package on test machine as following steps:
+
+    * Add BOT or Integrator account to robot-aio group by execute below command with root user or add it as a **RUN** step of Docker file 
+
+      .. code-block::
+
+        usermod -a -G robot-aio $BOT_USER
+
+    * Login as BOT or Integrator account
+
+    * Execute **initRobotFrameworkAIO.sh** script to setup enviroment or add it as **CMD** step when starting Docker container
+
+      .. code-block::
+      
+        initRobotFrameworkAIO.sh
+
+    * Now, execute your Robotframework test case/suite. E.g 
+
+      .. code-block::
+
+        robot ~/RobotTest/testcases/HelloWorld.robot
+  
+  * Added executable **appium** script to start the Appium server in command line (useful for Docker container)
+
+    .. code-block::
+
+      $RobotDevtools/appium
 "
                               ]
                  }

--- a/config/tools/appium.sh
+++ b/config/tools/appium.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export ANDROID_HOME=/opt/rfwaio/devtools/Android; 
+export APPIUM_HOME=/opt/rfwaio/devtools/nodejs/lib; 
+/opt/rfwaio/devtools/nodejs/bin/node /opt/rfwaio/devtools/nodejs/bin/appium


### PR DESCRIPTION
Hi Thomas,

This PR contains changes for issue #296.

Now, it grants permission for `robot-aio` group to `robotframework-aio` packages instead of deprecated detecting user group method which used since OSD4.
It helps to setup environment for non-root user (who is not permitted to update file/folder permission).

Please refer [change in release_info](https://github.com/test-fullautomation/RobotFramework_AIO/pull/300/files#diff-aa5a18be88ba6725f39f78adf70701133e3c1d17fa006876bad94862dba377d2) for more detail.

Thank you,
Ngoan