### PR TITLE
update script to tag repos by their version to support filename which contains version

### DIFF
--- a/config/repositories/publish_pypi_repos.txt
+++ b/config/repositories/publish_pypi_repos.txt
@@ -11,4 +11,4 @@ robotframework-robotlog2rqm
 robotframework-dbus
 robotframework-qconnect-winapp
 robotframework-doip
-robotframework-prometheus
+robotframework-prometheus=prometheus_interface.py


### PR DESCRIPTION
Hi Holger,

I updated tools and configuration files to tag repositories by their version for releasing as our discussion #301.
- Configuration file allow filename which contains version information.
- Your variable name `LIBRARY_VERSION` is also fine with the variable pattern I used to get version info.

I have reverted my changes accordingly in PR for Prometheus package
https://github.com/test-fullautomation/robotframework-prometheus/pull/14

Please review and give your feeling about both PR.

Thank you,
Ngoan
