### PR TITLE
Add the configuration for the tag repository

### DIFF
--- a/config/repositories/tag_repos.json
+++ b/config/repositories/tag_repos.json
@@ -19,6 +19,7 @@
          "robotframework-testsuitesmanagement": "",
          "robotframework-tutorial": "",
          "robotframework-doip": "",
+         "robotframework-prometheus": "",
          "testresultwebapp": "",
          "vscode-jsonp": "",
          "robotframework-dbus": "",

--- a/config/robotframework_aio/release_items_Robotframework_AIO.json
+++ b/config/robotframework_aio/release_items_Robotframework_AIO.json
@@ -164,6 +164,8 @@
 
 * Integrated **robotframework-prometheus** library
 * Integrated **prometheus_client** library
+* Integrated **pika** library
+
 
 
 **Python Package Index (PyPI)**

--- a/install/python_requirements.txt
+++ b/install/python_requirements.txt
@@ -56,7 +56,8 @@ paho-mqtt
 paramiko             
 # parsel               
 path.py              
-# pbr                  
+# pbr     
+pika             
 pickleDB             
 pillow
 # pip                  

--- a/install/python_requirements_lx.txt
+++ b/install/python_requirements_lx.txt
@@ -58,7 +58,8 @@ paho-mqtt
 paramiko             
 # parsel               
 path.py              
-# pbr                  
+# pbr  
+pika                
 pickleDB             
 pillow
 # pip                  


### PR DESCRIPTION
Hi Thomas,

I have updated the configuration to tag the prometheus repository to fix the error at clone job.
Beside that, I also integrate the pika library as the dependent library for DevAtServ tool.
Please help me merge it.

Thank you and best regards,
Thong Hua