### PR TITLE
update robotframework-appiumlibrary to latest version to fix its dependencies issues

### DIFF
--- a/install/python_requirements.txt
+++ b/install/python_requirements.txt
@@ -99,8 +99,7 @@ QLed
 qtawesome   
 requests             
 # requests-ntlm  
-Appium-Python-Client==3.1.1
-robotframework-appiumlibrary==2.0.0
+robotframework-appiumlibrary
 robotframework-ftplibrary     
 robotframework-listenerlibrary
 robotframework-mqttlibrary    

--- a/install/python_requirements_lx.txt
+++ b/install/python_requirements_lx.txt
@@ -105,8 +105,7 @@ QLed
 qtawesome           
 requests             
 # requests-ntlm  
-Appium-Python-Client==3.1.1
-robotframework-appiumlibrary==2.0.0
+robotframework-appiumlibrary
 robotframework-ftplibrary     
 robotframework-listenerlibrary
 robotframework-mqttlibrary    


### PR DESCRIPTION
Hi Thomas,

I observed that `robotframework-appiumlibrary` library has released new version `2.1.0` 2 weeks ago after long time without release (the previous release `2.0.0` is since Nov 2022).
This release solves a lot of issues which includes the incompatible issues of `Python-Appium-Client` (that I have to fix version in our build) and `selenium` (as issue #274) .
https://github.com/serhatbolsu/robotframework-appiumlibrary/releases

So that I updated python requirements file to use the latest version of `robotframework-appiumlibrary` for our AIO package.

Thank you,
Ngoan