### PR TITLE
add missing release info for VScodium and robotframework-appiumlibrary

### DIFF
--- a/config/robotframework_aio/release_items_Robotframework_AIO.json
+++ b/config/robotframework_aio/release_items_Robotframework_AIO.json
@@ -165,8 +165,11 @@
 * Integrated **robotframework-prometheus** library
 * Integrated **prometheus_client** library
 * Integrated **pika** library
+* Updated **robotframework-appiumlibrary** library to use latest vesion
 
+**VSCodium Package**
 
+* Updated from VSCodium version **1.73.0.22306** to latest version **1.90.2.24171**
 
 **Python Package Index (PyPI)**
 


### PR DESCRIPTION
Hi Thomas,

I added missing release info for `VSCodium` and `robotframework-appiumlibrary` updates.

Thank you,
Ngoan