### PR TITLE
update build pipeline to add Robotframework AIO document as artifact

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -138,6 +138,12 @@ jobs:
           name: linux-package
           path: output_lx/*.deb
 
+      - name: Upload documentation
+        uses: actions/upload-artifact@v3
+        with:
+          name: RobotFrameworkAIO_Reference
+          path: ${{ runner.workspace }}/robotframework-documentation/RobotFrameworkAIO/RobotFrameworkAIO_Reference.pdf
+
   build-windows:
     name: Build Windows package
     runs-on: windows-latest


### PR DESCRIPTION
Hi Thomas,

This PR add the Robotframework AIO document as [RobotFrameworkAIO_Reference](https://github.com/test-fullautomation/RobotFramework_AIO/actions/runs/9936181945/artifacts/1701051850) artifact in OSS build pipeline as issue #322 .

Thank you,
Ngoan