### PR TITLE
GitHub release text must contain content of release info files

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -233,6 +233,7 @@ jobs:
       run: |
         "%RobotPythonPath%\python" .\tools\release_info\release_info.py --configfile ".\release_info_config_OSS.json"
         move .\tools\release_info\release_info_RobotFramework_AIO_*.html ..\
+        move .\tools\release_info\release_changelog.html ..\
          
     - name: Upload test result as artifact
       if: success() || failure()
@@ -248,6 +249,7 @@ jobs:
           ${{ runner.workspace }}/[Pp]ython*/**/*/testlogfiles/*
           ${{ runner.workspace }}/Robotframework_AIO/console_log.txt
           ${{ runner.workspace }}/release_info_RobotFramework_AIO_*.html
+          ${{ runner.workspace }}/release_changelog.html
           ${{ runner.workspace }}/Robotframework_AIO/install-windows.log
 
 
@@ -309,6 +311,8 @@ jobs:
   release:
     name: Release AIO
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [install-test-windows, install-test-linux]
     if: ${{ ! failure() && ! cancelled() && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/rel/aio/') }}
 
@@ -323,46 +327,17 @@ jobs:
         echo "RELEASE_INFO_FILE=$(ls windows-aiotestlogfiles/release_info_RobotFramework_AIO_${TAG_NAME#rel/aio/}.html)" >> $GITHUB_ENV
         echo "RELEASE_VERSION=${TAG_NAME#rel/aio/}" >> $GITHUB_ENV
 
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ env.TAG_NAME }}
-        release_name: RobotFramework AIO version ${{ env.RELEASE_VERSION }}
-        draft: false
-        prerelease: false
 
-    - name: Upload Windows Release Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create/Update GitHub Release
+      id: create_update_release
+      uses: ncipollo/release-action@v1
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ${{ env.EXE_FILE }}
-        asset_name: setup_RobotFramework_AIO_Win_${{ env.RELEASE_VERSION }}.exe
-        asset_content_type: application/octet-stream
-
-    - name: Upload Linux Release Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ${{ env.DEB_FILE }}
-        asset_name: setup_RobotFramework_AIO_Linux_${{ env.RELEASE_VERSION }}.deb
-        asset_content_type: application/vnd.debian.binary-package
-    
-    - name: Upload Release Info Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ${{ env.RELEASE_INFO_FILE }}
-        asset_name: release_info_RobotFramework_AIO_${{ env.RELEASE_VERSION }}.html
-        asset_content_type: text/html
+        allowUpdates: true
+        omitNameDuringUpdate: true
+        makeLatest: true
+        name: RobotFramework AIO version ${{ env.RELEASE_VERSION }}
+        artifacts: "windows-package/*.exe,linux-package/*.deb,windows-aiotestlogfiles/release_info_RobotFramework_AIO_*.html"
+        bodyFile: "windows-aiotestlogfiles/release_changelog.html"
 
   tag-to-publish-packges-to-pypi:
     name: Tag Python packages to trigger workflow for publishing to PyPI

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -320,13 +320,9 @@ jobs:
     - name: Download artifact from build workflow
       uses: actions/download-artifact@v3
 
-    - name: Get released file names
+    - name: Get released version
       run: |
-        echo "EXE_FILE=$(ls windows-package/*.exe | head -1)" >> $GITHUB_ENV
-        echo "DEB_FILE=$(ls linux-package/*.deb | head -1)" >> $GITHUB_ENV
-        echo "RELEASE_INFO_FILE=$(ls windows-aiotestlogfiles/release_info_RobotFramework_AIO_${TAG_NAME#rel/aio/}.html)" >> $GITHUB_ENV
         echo "RELEASE_VERSION=${TAG_NAME#rel/aio/}" >> $GITHUB_ENV
-
 
     - name: Create/Update GitHub Release
       id: create_update_release

--- a/tools/release_info/libs/COutput.py
+++ b/tools/release_info/libs/COutput.py
@@ -312,12 +312,16 @@ class COutput():
       listHTMLChangelog = []
       listIdentifiedComponents = list(dictListOfChangesPerComponent.keys())
       nCnt = 0
+      nCntCmpt = 1
       if len(listIdentifiedComponents) > 0:
          # someting found, therefore start a table
          listLinesHTML.append(self.__oPattern.GetChangesTableBegin())
-         listHTMLChangelog.append(self.__oPattern.GetChangesTableBegin())
+         listHTMLChangelog.append("<h2>Changelog</h2>")
          for sIdentifiedComponent in listIdentifiedComponents:
             listChanges = dictListOfChangesPerComponent[sIdentifiedComponent]
+            if listChanges:
+               listHTMLChangelog.append(f"<h3>{nCntCmpt}. {sIdentifiedComponent}</h3>")
+               nCntCmpt = nCntCmpt + 1
             for sChange in listChanges:
                nCnt = nCnt + 1
                sChange_conv = pypandoc.convert_text(sChange, 'html', format='rst')
@@ -327,10 +331,9 @@ class COutput():
                sChange_conv = sChange_conv.replace("<code>", "<code><font font-family=\"courier new\" color=\"navy\" size=\"+1\">")
                sChange_conv = sChange_conv.replace("</code>", "</font></code>")
                listLinesHTML.append(self.__oPattern.GetChangesTableDataRow(nCnt, sIdentifiedComponent, sChange_conv))
-               listHTMLChangelog.append(self.__oPattern.GetChangesTableDataRow(nCnt, sIdentifiedComponent, sChange_conv))
+               listHTMLChangelog.append(sChange_conv)
 
          listLinesHTML.append(self.__oPattern.GetTableFooter())
-         listHTMLChangelog.append(self.__oPattern.GetTableFooter())
          listLinesHTML.append(self.__oPattern.GetVDist())
       # eof if len(listIdentifiedComponents) > 0:
 
@@ -365,7 +368,8 @@ class COutput():
 
       # write changelog html file
       oReleaseChangelogFileHTML = CFile(sReleaseChangelogFileHTML)
-      oReleaseChangelogFileHTML.Write("\n".join(listHTMLChangelog).replace("\r\n", " "))
+      sChangelogContent = "\n".join(listHTMLChangelog).replace("\r\n", " ")
+      oReleaseChangelogFileHTML.Write(sChangelogContent)
       del oReleaseChangelogFileHTML
 
       listResults.append(f"Release changelog written to '{sReleaseChangelogFileHTML}'")

--- a/tools/release_info/libs/COutput.py
+++ b/tools/release_info/libs/COutput.py
@@ -338,12 +338,13 @@ class COutput():
       if len(listIdentifiedComponents) > 0:
          # someting found, therefore start a table
          listLinesHTML.append(self.__oPattern.GetChangesTableBegin())
-         listHTMLChangelog.append("<h2>Changelog</h2>")
+         listHTMLChangelog.append(self.__oPattern.GetChangeLogTableBegin())
          for sIdentifiedComponent in listIdentifiedComponents:
             listChanges = dictListOfChangesPerComponent[sIdentifiedComponent]
+            sHTMLChangelogCmpt = ''
             if listChanges:
-               listHTMLChangelog.append(f"<h3>{nCntCmpt}. {sIdentifiedComponent}</h3>")
                nCntCmpt = nCntCmpt + 1
+               sHTMLChangelogCmpt = sHTMLChangelogCmpt + f"<h3>{sIdentifiedComponent}</h3>"
             for sChange in listChanges:
                nCnt = nCnt + 1
                sChange_conv = pypandoc.convert_text(sChange, 'html', format='rst')
@@ -353,7 +354,10 @@ class COutput():
                sChange_conv = sChange_conv.replace("<code>", "<code><font font-family=\"courier new\" color=\"navy\" size=\"+1\">")
                sChange_conv = sChange_conv.replace("</code>", "</font></code>")
                listLinesHTML.append(self.__oPattern.GetChangesTableDataRow(nCnt, sIdentifiedComponent, sChange_conv))
-               listHTMLChangelog.append(sChange_conv)
+               sHTMLChangelogCmpt = sHTMLChangelogCmpt + sChange_conv
+            
+            if sHTMLChangelogCmpt:
+               listHTMLChangelog.append(self.__oPattern.GetChangeLogTableDataRow(sHTMLChangelogCmpt))
 
          listLinesHTML.append(self.__oPattern.GetTableFooter())
          listLinesHTML.append(self.__oPattern.GetVDist())

--- a/tools/release_info/libs/COutput.py
+++ b/tools/release_info/libs/COutput.py
@@ -100,6 +100,7 @@ class COutput():
       sReleaseInfoFileHTMLName = f"release_info_{bundle_name}_{bundle_version}.html"
       sReleaseInfoFileHTMLName = sReleaseInfoFileHTMLName.replace(" ", "_")
       sReleaseInfoFileHTML     = f"{REFERENCEPATH_CONFIG}/{sReleaseInfoFileHTMLName}"
+      sReleaseChangelogFileHTML= f"{REFERENCEPATH_CONFIG}/release_changelog.html"
 
       self.__oConfig.Set('RELEASEINFOFILEHTML', sReleaseInfoFileHTML)
 
@@ -308,11 +309,13 @@ class COutput():
             dictListOfChangesPerComponent[sComponent].extend(listChanges)
       # eof for sComponent in listComponentsAll:
 
+      listHTMLChangelog = []
       listIdentifiedComponents = list(dictListOfChangesPerComponent.keys())
       nCnt = 0
       if len(listIdentifiedComponents) > 0:
          # someting found, therefore start a table
          listLinesHTML.append(self.__oPattern.GetChangesTableBegin())
+         listHTMLChangelog.append(self.__oPattern.GetChangesTableBegin())
          for sIdentifiedComponent in listIdentifiedComponents:
             listChanges = dictListOfChangesPerComponent[sIdentifiedComponent]
             for sChange in listChanges:
@@ -324,8 +327,10 @@ class COutput():
                sChange_conv = sChange_conv.replace("<code>", "<code><font font-family=\"courier new\" color=\"navy\" size=\"+1\">")
                sChange_conv = sChange_conv.replace("</code>", "</font></code>")
                listLinesHTML.append(self.__oPattern.GetChangesTableDataRow(nCnt, sIdentifiedComponent, sChange_conv))
+               listHTMLChangelog.append(self.__oPattern.GetChangesTableDataRow(nCnt, sIdentifiedComponent, sChange_conv))
 
          listLinesHTML.append(self.__oPattern.GetTableFooter())
+         listHTMLChangelog.append(self.__oPattern.GetTableFooter())
          listLinesHTML.append(self.__oPattern.GetVDist())
       # eof if len(listIdentifiedComponents) > 0:
 
@@ -355,6 +360,13 @@ class COutput():
       oReleaseInfoFileHTML = CFile(sReleaseInfoFileHTML)
       oReleaseInfoFileHTML.Write(sHTMLCode)
       del oReleaseInfoFileHTML
+
+      listResults.append(f"Release info written to '{sReleaseInfoFileHTML}'")
+
+      # write changelog html file
+      oReleaseChangelogFileHTML = CFile(sReleaseChangelogFileHTML)
+      oReleaseChangelogFileHTML.Write("\n".join(listHTMLChangelog))
+      del oReleaseChangelogFileHTML
 
       listResults.append(f"Release info written to '{sReleaseInfoFileHTML}'")
 

--- a/tools/release_info/libs/COutput.py
+++ b/tools/release_info/libs/COutput.py
@@ -365,10 +365,10 @@ class COutput():
 
       # write changelog html file
       oReleaseChangelogFileHTML = CFile(sReleaseChangelogFileHTML)
-      oReleaseChangelogFileHTML.Write("\n".join(listHTMLChangelog))
+      oReleaseChangelogFileHTML.Write("\n".join(listHTMLChangelog).replace("\r\n", " "))
       del oReleaseChangelogFileHTML
 
-      listResults.append(f"Release info written to '{sReleaseInfoFileHTML}'")
+      listResults.append(f"Release changelog written to '{sReleaseChangelogFileHTML}'")
 
       # -- output to email
 

--- a/tools/release_info/libs/CPattern.py
+++ b/tools/release_info/libs/CPattern.py
@@ -318,4 +318,23 @@ class CPattern():
    # --------------------------------------------------------------------------------------------------------------
    #TM***
 
+   # --------------------------------------------------------------------------------------------------------------
+   #TM***
+
+   def GetChangeLogTableBegin(self):
+      sChangelogTableBegin = """<h3><font face="Arial" color="#242424">Changelog</font></h3>
+<table width="100%" border="1" cellspacing="0" cellpadding="0" frame="box" rules="all" align="left">
+"""
+      return sChangelogTableBegin
+
+   # --------------------------------------------------------------------------------------------------------------
+   #TM***
+
+   def GetChangeLogTableDataRow(self, sChangeLog=None):
+      sChangeLogTableDataRow = """<tr>
+   <td bgcolor="#F5F5F5" width="100%" align="left" style="padding:6pt 6pt 6pt 6pt"><font face="Arial" color="#000000" size="-1">###CHANGELOG###</font></td>
+</tr>
+"""
+      sChangeLogTableDataRow = sChangeLogTableDataRow.replace("###CHANGELOG###", f"{sChangeLog}")
+      return sChangeLogTableDataRow
 


### PR DESCRIPTION
Hi team,

This PR implements the issue #324.

I have extended current `release_info` tool to generate the `release_changelog.html` file which is used as Github Release content.
I used flat format for Github Release content instead of table of release_info html file. I have tried with table format before but my feeling is not good.

Referent Github Release content: https://github.com/ngoan1608/RobotFramework_AIO/releases/tag/rel%2Faio%2F0.13.0.6

(Referent content that uses table format: https://github.com/ngoan1608/RobotFramework_AIO/releases/tag/rel%2Faio%2F0.13.0.5)

Please review and give feeling about it.

Thank you,
Ngoan