### PR TITLE
allow VERSION and LABEL as variables in release contents

### DIFF
--- a/tools/release_info/libs/COutput.py
+++ b/tools/release_info/libs/COutput.py
@@ -66,6 +66,15 @@ def IsVersionMatch(bundle_version, release_info_version):
 
 # --------------------------------------------------------------------------------------------------------------
 
+def resolveVariable(sContent, dVarMapping):
+   """Helps to resolve variable (define with ###VAR### syntax) by its value in given content
+   """
+   sResolvedLine = sContent
+   for var, value in dVarMapping.items():
+      sResolvedLine = sResolvedLine.replace(f"###{var}###", value)
+   
+   return sResolvedLine
+
 class COutput():
    """produce the output (currently HTML and email)
    """
@@ -120,6 +129,13 @@ class COutput():
       RELEASE_MAIN_INFO = self.__oConfig.Get('RELEASE_MAIN_INFO')
       listVersionNumbersAll = list(RELEASE_MAIN_INFO.keys())
 
+      # prepare variable mapping for replacement in release main info 
+      lBundleVersion = bundle_version.split('.')
+      dVariableMapping = {
+         "VERSION": '.'.join(lBundleVersion[:4]),
+         "LABEL": '.'.join(lBundleVersion[:3])
+      }
+
       # -- find version number matches
 
       # PrettyPrint(listVersionNumbersAll, sPrefix="listVersionNumbersAll")
@@ -166,7 +182,8 @@ class COutput():
 
       listofdictLinks = []
       for sLink in listLinksRaw:
-         listLinkParts = sLink.split(';')
+         sResolvedLink = resolveVariable(sLink, dVariableMapping)
+         listLinkParts = sResolvedLink.split(';')
          # PrettyPrint(listLinkParts, sPrefix="listLinkParts")
          nNrOfParts = len(listLinkParts)
          dictLink = {}
@@ -206,7 +223,8 @@ class COutput():
          # found 'RELEASENOTES' => write to output
          listLinesHTML.append(self.__oPattern.GetReleaseNotesTableBegin())
          for sReleaseNote in listReleaseNotes:
-            sReleaseNote_conv = pypandoc.convert_text(sReleaseNote, 'html', format='rst')
+            sReleaseNote_resolve = resolveVariable(sReleaseNote, dVariableMapping)
+            sReleaseNote_conv = pypandoc.convert_text(sReleaseNote_resolve, 'html', format='rst')
             # to open link in another explorer window:
             sReleaseNote_conv = sReleaseNote_conv.replace("a href=", "a target=\"_blank\" href=")
             # <code> tag fix: size and color
@@ -222,7 +240,8 @@ class COutput():
          # found 'HIGHLIGHTS' => write to output
          listLinesHTML.append(self.__oPattern.GetHighlightsTableBegin())
          for sHighlight in listHighlights:
-            sHighlight_conv = pypandoc.convert_text(sHighlight, 'html', format='rst')
+            sHighlight_resolve = resolveVariable(sHighlight, dVariableMapping)
+            sHighlight_conv = pypandoc.convert_text(sHighlight_resolve, 'html', format='rst')
             # to open link in another explorer window:
             sHighlight_conv = sHighlight_conv.replace("a href=", "a target=\"_blank\" href=")
             # <code> tag fix: size and color
@@ -238,7 +257,8 @@ class COutput():
          # found 'ADDITIONALINFORMATION' => write to output
          listLinesHTML.append(self.__oPattern.GetAdditionalInformationTableBegin())
          for sAdditionalInformation in listAdditionalInformation:
-            sAdditionalInformation_conv = pypandoc.convert_text(sAdditionalInformation, 'html', format='rst')
+            sAdditionalInformation_resolved = resolveVariable(sAdditionalInformation, dVariableMapping)
+            sAdditionalInformation_conv = pypandoc.convert_text(sAdditionalInformation_resolved, 'html', format='rst')
             # to open link in another explorer window:
             sAdditionalInformation_conv = sAdditionalInformation_conv.replace("a href=", "a target=\"_blank\" href=")
             # <code> tag fix: size and color
@@ -254,7 +274,8 @@ class COutput():
          # found 'REQUIREMENTS' => write to output
          listLinesHTML.append(self.__oPattern.GetRequirementsTableBegin())
          for sRequirement in listRequirements:
-            sRequirement_conv = pypandoc.convert_text(sRequirement, 'html', format='rst')
+            sRequirement_resolve = resolveVariable(sRequirement, dVariableMapping)
+            sRequirement_conv = pypandoc.convert_text(sRequirement_resolve, 'html', format='rst')
             # to open link in another explorer window:
             sRequirement_conv = sRequirement_conv.replace("a href=", "a target=\"_blank\" href=")
             # <code> tag fix: size and color
@@ -270,7 +291,8 @@ class COutput():
          # found 'RESTRICTIONS' => write to output
          listLinesHTML.append(self.__oPattern.GetRestrictionsTableBegin())
          for sRestriction in listRestrictions:
-            sRestriction_conv = pypandoc.convert_text(sRestriction, 'html', format='rst')
+            sRestriction_resolve = resolveVariable(sRestriction, dVariableMapping)
+            sRestriction_conv = pypandoc.convert_text(sRestriction_resolve, 'html', format='rst')
             # to open link in another explorer window:
             sRestriction_conv = sRestriction_conv.replace("a href=", "a target=\"_blank\" href=")
             # <code> tag fix: size and color

--- a/tools/release_info/release_main_info.json
+++ b/tools/release_info/release_main_info.json
@@ -668,8 +668,153 @@ Feel free to contact us when you use or intend to use **RobotFramework AIO**. We
                                              "https://github.com/test-fullautomation/vscode-jsonp/pulls?q=is%3Apr+is%3Aclosed+label%3A0.12.1; merged pull-requests; vscode-jsonp",
                                         "",  "https://gitlab-apertispro.boschdevcloud.com/robotframework-aio/main/build/-/merge_requests?scope=all&utf8=%E2%9C%93&state=merged&milestone_title=0.12.1; merged pull-requests; Gitlab build and CI"
                                           ]
-                      },  
-
+                      },
+   "0.13.0." : {
+                "RELEASENOTES"    : ["
+          Dear team,
+          
+          | After hard work we are proud to announce a **new release of the RobotFramework AIO (All In One) for Windows 10, OSD6 Linux, OSD7 Linux and Apertis**.
+          | Please feel free to give any feedback about your experiences and wishes!
+          
+          Feel free to contact us when you use or intend to use **RobotFramework AIO**. We are keen to support you!
+          
+          **What is RobotFramework AIO**
+          
+          - One installer brings after few clicks all you need to develop and execute Robot Framework based test cases. We support you in case of any wishes. 
+             
+           You are free to request changes.
+          
+          - **RobotFramework AIO** is installed transparently for all other applications. It will not interfere with existing installations of e.g. Python or `VSCodium <https://vscodium.com/>`_ (OSS version of Visual Studio Code).
+          
+          - Preconfigured `VSCodium <https://vscodium.com/>`_ (OSS version of Visual Studio Code) integrates “Hello, world!” work space for immediate execution of *.robot and .py files.
+          
+          - Large tutorial how to work with **RobotFramework AIO** as part of our preconfigured `VSCodium <https://vscodium.com/>`_ (e.g. how to configure testsuites, how to work with different data types, static code analysis, ...).
+          
+          - Integrated `RobotFramework_TestsuitesManagement <https://github.com/test-fullautomation/robotframework-testsuitesmanagement/blob/develop/RobotFramework_TestsuitesManagement/RobotFramework_TestsuitesManagement.pdf>`_ with `JSON <https://www.json.org/json-de.html>`_ based configuration files for unlimited variant/project-configurations.
+             - Extended JSON syntax (e.g. comments, imports, variables).
+             - ${variable} allows reuse of already defined variables on `JSON <https://www.json.org/json-de.html>`_ level.
+             - \".\" (dot)-syntax allows easy navigation through object hierarchies.
+                        "],
+                "HIGHLIGHTS"      : ["
+          **New**
+          
+          (Your update here)
+  
+          
+          **General**
+          
+          - Improved continuous test as part of pipeline.
+          
+          - RobotFramework core version 6.0.2 as base.
+          
+          - All preinstalled OSS **RobotFramework AIO** libraries available in OSS Python package index `pypi <https://pypi.org/>`_ now as part of release process: e.g. 
+            
+            `robotframework-testsuitesmanagement <https://pypi.org/project/robotframework-testsuitesmanagement/>`_,
+            `robotframework-qconnect-base <https://pypi.org/project/robotframework-qconnect-base/>`_,
+            `robotframework-robotlog2db <https://pypi.org/project/robotframework-robotlog2db/>`_,
+            `JsonPreprocessor <https://pypi.org/project/JsonPreprocessor/>`_,
+            `GenPackageDoc <https://pypi.org/project/GenPackageDoc/>`_, ...
+          
+          - Improved installation and pre-configuration.
+          
+          - Massive improvement of stability and usability of our `RobotFramework_TestsuitesManagement <https://github.com/test-fullautomation/robotframework-testsuitesmanagement/blob/develop/RobotFramework_TestsuitesManagement/RobotFramework_TestsuitesManagement.pdf>`_.
+          
+          - VSCodium recognize “.jsonp” as JSON files with extended syntax used by `RobotFramework_TestsuitesManagement <https://github.com/test-fullautomation/robotframework-testsuitesmanagement/blob/develop/RobotFramework_TestsuitesManagement/RobotFramework_TestsuitesManagement.pdf>`_.
+          
+          - Queued connectivity for 
+            `DLT <https://sourcecode.socialcoding.bosch.com/projects/ROBFW/repos/robotframework-qconnect-dlt/browse>`_, 
+            `TTFIS <https://sourcecode.socialcoding.bosch.com/projects/ROBFW/repos/robotframework-qconnect-dlt/browse>`_, 
+            `serial port <https://github.com/test-fullautomation/robotframework-qconnect-base/blob/develop/QConnectBase/QConnectBase.pdf>`_, 
+            `SSH <https://github.com/test-fullautomation/robotframework-qconnect-base/blob/develop/QConnectBase/QConnectBase.pdf>`_, 
+            `TCP <https://github.com/test-fullautomation/robotframework-qconnect-base/blob/develop/QConnectBase/QConnectBase.pdf>`_.
+          
+          - WebApp and WebApp interface to process your test result data (inclusive diffing of different test suite executions).
+          
+           Example: `CMD WebApp Dashboard <http://www-app.hi.de.bosch.com/CMD_BVT/index.html?branch=main&variant=rnaivi2&version=9108dbaf-bd2f-4be0-86f9-8bbe469167e7&component=All%20Components>`_
+           
+           Diff View: `CMD WebApp Diff <http://www-app.hi.de.bosch.com/CMD_BVT/index.html?branch=main&variant=rnaivi2&version=89706ec5-69ba-4322-b56f-b484d6ce0ec5&component=All%20Components&view=diffview&stack=3dfda2ef-699e-4ac9-89da-6a3433351fcc%3B89706ec5-69ba-4322-b56f-b484d6ce0ec5>`_
+          
+          - Integrated RFW-libraries (tag RFW-2.0).
+          
+          - General: improved all documentations and self tests.
+                          "],
+                "ADDITIONALINFORMATION" : ["
+          **GITHUB git tag**
+            **rel/aio/###VERSION###**
+          
+            `github <https://github.com/test-fullautomation?tab=repositories>`_
+            (Please feel free to contribute!)
+                        
+          **BIOS git tag**
+            **rel/aio/###VERSION###**
+            
+            `BIOS <https://sourcecode.socialcoding.bosch.com/projects/ROBFW>`_
+            (Please feel free to contribute!)
+                        
+          **ApertisPro git tag**
+            **rel/###VERSION###**
+            
+            `gitlab <https://gitlab-apertispro.boschdevcloud.com/robotframework-aio/main>`_
+            (Please feel free to contribute!)
+            
+          ----
+            
+          **Issue / CRQ Tracking**
+            `T&R Jira <https://rb-tracker.bosch.com/tracker01/secure/RapidBoard.jspa?rapidView=13300&view=planning.nodetail&issueLimit=100>`_
+            (Please feel free to create support requests or change requests here!)
+          
+          ----
+          
+          **Download**
+            `RobotFramework AIO Windows <file://///bosch.com/dfsrb/DfsDE/DIV/CM/DI/Projects/Common/RobotFramework/Releases/###LABEL###/>`_
+          
+            `RobotFramework AIO OSD6 <file://///bosch.com/dfsrb/DfsDE/DIV/CM/DI/Projects/Common/RobotFramework/Releases/###LABEL###/>`_
+          
+            `RobotFramework AIO OSD7 <file://///bosch.com/dfsrb/DfsDE/DIV/CM/DI/Projects/Common/RobotFramework/Releases/###LABEL###/>`_
+          
+            `RobotFramework AIO Apertis <file://///bosch.com/dfsrb/DfsDE/DIV/CM/DI/Projects/Common/RobotFramework/Releases/###LABEL###/>`_
+            
+          **Download OSS versions** 
+            `RobotFramework AIO OSS Windows <file://///bosch.com/dfsrb/DfsDE/DIV/CM/DI/Projects/Common/RobotFramework/Releases/###LABEL###/>`_
+          
+            `RobotFramework AIO OSS Ubuntu <file://///bosch.com/dfsrb/DfsDE/DIV/CM/DI/Projects/Common/RobotFramework/Releases/###LABEL###/>`_
+          
+          ----
+          
+          **How to Install**
+           Chapter 2, page 2 of `RobotFrameworkAIO_Reference.pdf <https://github.com/test-fullautomation/robotframework-documentation/blob/develop/RobotFrameworkAIO/RobotFrameworkAIO_Reference.pdf>`_ 
+                                          "],                              
+          #               "REQUIREMENTS"    : ["
+          #               
+          #               
+          #                              
+          #                              "],
+                "VERSIONEDLINKS"  : [
+                                      "https://github.com/test-fullautomation/python-extensions-collection/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; python-extensions-collection",
+                                      "https://github.com/test-fullautomation/python-genpackagedoc/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; python-genpackagedoc",
+                                      "https://github.com/test-fullautomation/python-jsonpreprocessor/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; python-jsonpreprocessor",
+                                      "https://github.com/test-fullautomation/python-microservice-base/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; python-microservice-base",
+                                      "https://github.com/test-fullautomation/python-microservice-cleware-switch/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; python-microservice-cleware-switch",
+                                      "https://github.com/test-fullautomation/python-pytestlog2db/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; python-pytestlog2db",
+                                  "",  "https://github.com/test-fullautomation/robotframework/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; robotframework (core)",
+                                      "https://github.com/test-fullautomation/robotframework-dbus/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; robotframework-dbus",
+                                      "https://github.com/test-fullautomation/robotframework-documentation/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; robotframework-documentation",
+                                      "https://github.com/test-fullautomation/robotframework-doip/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; robotframework-doip",
+                                      "https://github.com/test-fullautomation/robotframework-extensions-collection/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; robotframework-extensions-collectionnnn",
+                                      "https://github.com/test-fullautomation/robotframework-lsp/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; robotframework-lsp",
+                                      "https://github.com/test-fullautomation/robotframework-qconnect-base/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; robotframework-qconnect-base",
+                                      "https://github.com/test-fullautomation/robotframework-qconnect-winapp/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; robotframework-qconnect-winapp",
+                                      "https://github.com/test-fullautomation/robotframework-robotlog2db/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; robotframework-robotlog2db",
+                                      "https://github.com/test-fullautomation/robotframework-robotlog2rqm/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; robotframework-robotlog2rqm",
+                                      "https://github.com/test-fullautomation/robotframework-selftest/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; robotframework-selftest",
+                                      "https://github.com/test-fullautomation/robotframework-testsuitesmanagement/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; robotframework-testsuitesmanagement",
+                                      "https://github.com/test-fullautomation/robotframework-tutorial/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; robotframework-tutorial",
+                                  "",  "https://github.com/test-fullautomation/RobotFramework_AIO/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; RobotFramework_AIO (build)",
+                                      "https://github.com/test-fullautomation/testresultwebapp/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; testresultwebapp",
+                                      "https://github.com/test-fullautomation/vscode-jsonp/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###; merged pull-requests; vscode-jsonp",
+                                  "",  "https://gitlab-apertispro.boschdevcloud.com/robotframework-aio/main/build/-/merge_requests?scope=all&utf8=%E2%9C%93&state=merged&milestone_title###LABEL###; merged pull-requests; Gitlab build and CI"
+                                    ]
+                       },
              
    # --------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Hi Thomas,

This PR fixes issue #316 to allow `VERSION` and `LABEL` as variable in release info contents.
These variable are replace with appropriate version information.

I have also added the release content for version `0.13.0.x`  in `release_main_info.json` file which is adapted with this change.
Please update **New** section (and others if requires) for the coming release.

Thank you,
Ngoan