### PR TITLE
try to update user permission for vscodium in post install

### DIFF
--- a/scripts/RobotFrameworkSetup.iss
+++ b/scripts/RobotFrameworkSetup.iss
@@ -431,16 +431,22 @@ begin
   //directly after installation this will be executed
   if CurStep=ssPostInstall then
     begin
+      GetWindowsVersionEx(Version);
+      if (Version.NTPlatform) and (Version.Major>=6) then
+        begin
+          Win7GiveWriteAccess('{app}\robotvscode\data');
+          Win7GiveWriteAccess('{app}\devtools');
+        end;
 
 #ifdef DoInstallTracking
-        //installation tracking
-        try
-           WinHttpReq := CreateOleObject('WinHttp.WinHttpRequest.5.1');
-           WinHttpReq.Open('GET', ExpandConstant('{#InstallTrackingService}?v={#MyAppVersion};u={username};m={computername};d={%USERDOMAIN};f='+sNewInstallation), false);
-           WinHttpReq.Send();  
-        except
-           //ignore any issue. Setup must complete...
-        end;
+      //installation tracking
+      try
+          WinHttpReq := CreateOleObject('WinHttp.WinHttpRequest.5.1');
+          WinHttpReq.Open('GET', ExpandConstant('{#InstallTrackingService}?v={#MyAppVersion};u={username};m={computername};d={%USERDOMAIN};f='+sNewInstallation), false);
+          WinHttpReq.Send();  
+      except
+          //ignore any issue. Setup must complete...
+      end;
 #endif
 
 


### PR DESCRIPTION
Hi Thomas,

I bring back the `Win7GiveWriteAccess` function to update vscodium data folder permission in post installation.

Please help to double-check [this Windows installer](https://github.com/test-fullautomation/RobotFramework_AIO/actions/runs/10400217740/artifacts/1814831381) on your machine
I have tried to install/uninstall some times to verify it, it seems to work fine.

Thank you,
Ngoan

