### PR TITLE
Github copilot plugin delivered with vscodium

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -30,6 +30,7 @@ env:
   BUNDLE_NAME: --bundle_name "RobotFramework AIO"
   GENDOC_PLANTUML_PATH: "../robotvscode/data/extensions/jebbs.plantuml-2.17.5"
   INSTALLER_LOCATION: "https://github.com/test-fullautomation/RobotFramework_AIO/releases"
+  GITHUB_COPILOT_REF_URL: "https://docs.github.com/en/enterprise-cloud@latest/copilot/managing-copilot/managing-copilot-as-an-individual-subscriber/managing-your-copilot-subscription"
 
 jobs:
   tag-repos:
@@ -89,6 +90,9 @@ jobs:
           # Environment variable for trigger process
           echo "REPOSITORY=${{needs.trigger-aio.outputs.repository}}" >> $GITHUB_ENV
           echo "PULL_REQUEST_BRANCH=${{needs.trigger-aio.outputs.branch}}" >> $GITHUB_ENV
+
+          # Update placeholders install-github-copilot-exts.sh script
+          sed -i "s|\$PLACEHOLDER_REF_URL|${GITHUB_COPILOT_REF_URL}|g" ./install/install-github-copilot-exts.sh
 
       - name: Clone repositories
         run: |
@@ -168,6 +172,9 @@ jobs:
           echo "BUNDLE_VERSION=--bundle_version \"${TAG_NAME#[rd]e[vl]/aio/}\"" >> $GITHUB_ENV
           echo "REPOSITORY=${{needs.trigger-aio.outputs.repository}}" >> $GITHUB_ENV
           echo "PULL_REQUEST_BRANCH=${{needs.trigger-aio.outputs.branch}}" >> $GITHUB_ENV
+
+          # Update placeholders install-github-copilot-exts.sh script
+          sed -i "s|\$PLACEHOLDER_REF_URL|${GITHUB_COPILOT_REF_URL}|g" ./install/install-github-copilot-exts.sh
 
       - name: Clone repositories
         shell: bash

--- a/build
+++ b/build
@@ -326,6 +326,8 @@ function build_debian()
 	# Vscodium package and RobotTest workspace
 	cp -R -a ../robotvscode/. ./output_lx/${PACK_NAME}/opt/rfwaio/robotvscode
 	cp -R -a ./config/RobotTest/. ./output_lx/${PACK_NAME}/opt/rfwaio/robotvscode/RobotTest
+	cp ./install/install-github-copilot-exts.sh ./output_lx/${PACK_NAME}/opt/rfwaio/robotvscode/install-github-copilot-exts.sh
+   chmod +x ./output_lx/${PACK_NAME}/opt/rfwaio/robotvscode/install-github-copilot-exts.sh
 
 	# Tutorial and Documentation packages
 	mkdir -p ./output_lx/${PACK_NAME}/opt/rfwaio/tutorial

--- a/config/build/dpkg_build/postinst.sh
+++ b/config/build/dpkg_build/postinst.sh
@@ -99,7 +99,11 @@ function update_vscodium_related(){
    sed -i "s|{RobotVsCode}|$VsCodePath|g" /opt/rfwaio/robotvscode/data/user-data/User/globalStorage/storage.json # > /opt/rfwaio/robotvscode/data/user-data/storage.json
 
    # install Github Copilot extensions for VsCodium from end-user due to the extension's license
-   read -p "Do you want to install Github Copilot extensions for VsCodium? (Y/N): " choice
+   read -rt 30 -p "Do you want to install Github Copilot extensions for VsCodium? (Y/N): " choice
+   # execute the script to install install Github Copilot as default (without input from user)
+   if [ -z "$choice" ]; then
+      choice="Y"
+   fi
    case "$choice" in
       Y|y|Yes|yes)
          echo "Installing Github Copilot extensions..."

--- a/config/build/dpkg_build/postinst.sh
+++ b/config/build/dpkg_build/postinst.sh
@@ -100,7 +100,7 @@ function update_vscodium_related(){
 
    # Remind user to install Github Copilot extensions for VsCodium
    INSTALL_COPILOT_EXTS_SCRIPT=/opt/rfwaio/robotvscode/install-github-copilot-exts.sh
-   if [ -d "${INSTALL_COPILOT_EXTS_SCRIPT}" ]; then
+   if [ -f "${INSTALL_COPILOT_EXTS_SCRIPT}" ]; then
       echo "For using Github Copilot extensions with VsCodium, please install them by below commands:"
       echo "${INSTALL_COPILOT_EXTS_SCRIPT}"
    fi

--- a/config/build/dpkg_build/postinst.sh
+++ b/config/build/dpkg_build/postinst.sh
@@ -98,24 +98,12 @@ function update_vscodium_related(){
    sed -i "s|{RobotTestPath}|$WpPath|g" /opt/rfwaio/robotvscode/data/user-data/User/globalStorage/storage.json # > /opt/rfwaio/robotvscode/data/user-data/storage.json
    sed -i "s|{RobotVsCode}|$VsCodePath|g" /opt/rfwaio/robotvscode/data/user-data/User/globalStorage/storage.json # > /opt/rfwaio/robotvscode/data/user-data/storage.json
 
-   # install Github Copilot extensions for VsCodium from end-user due to the extension's license
-   read -rt 30 -p "Do you want to install Github Copilot extensions for VsCodium? (Y/N): " choice
-   # execute the script to install install Github Copilot as default (without input from user)
-   if [ -z "$choice" ]; then
-      choice="Y"
+   # Remind user to install Github Copilot extensions for VsCodium
+   INSTALL_COPILOT_EXTS_SCRIPT=/opt/rfwaio/robotvscode/install-github-copilot-exts.sh
+   if [ -d "${INSTALL_COPILOT_EXTS_SCRIPT}" ]; then
+      echo "For using Github Copilot extensions with VsCodium, please install them by below commands:"
+      echo "${INSTALL_COPILOT_EXTS_SCRIPT}"
    fi
-   case "$choice" in
-      Y|y|Yes|yes)
-         echo "Installing Github Copilot extensions..."
-         /opt/rfwaio/robotvscode/install-github-copilot-exts.sh
-         ;;
-      N|n|No|no)
-         echo "Skipped Github Copilot extensions installation."
-         ;;
-      *)
-         echo "Invalid input. Skipped Github Copilot extensions installation."
-         ;;
-   esac
 }
 
 echo "Creating/Updating RobotFramework AIO runtime environment"

--- a/config/build/dpkg_build/postinst.sh
+++ b/config/build/dpkg_build/postinst.sh
@@ -97,6 +97,21 @@ function update_vscodium_related(){
    sed -i "s|{RobotPythonPath}|$PyPath|g" /opt/rfwaio/robotvscode/data/user-data/User/settings.json
    sed -i "s|{RobotTestPath}|$WpPath|g" /opt/rfwaio/robotvscode/data/user-data/User/globalStorage/storage.json # > /opt/rfwaio/robotvscode/data/user-data/storage.json
    sed -i "s|{RobotVsCode}|$VsCodePath|g" /opt/rfwaio/robotvscode/data/user-data/User/globalStorage/storage.json # > /opt/rfwaio/robotvscode/data/user-data/storage.json
+
+   # install Github Copilot extensions for VsCodium from end-user due to the extension's license
+   read -p "Do you want to install Github Copilot extensions for VsCodium? (Y/N): " choice
+   case "$choice" in
+      Y|y|Yes|yes)
+         echo "Installing Github Copilot extensions..."
+         /opt/rfwaio/robotvscode/install-github-copilot-exts.sh
+         ;;
+      N|n|No|no)
+         echo "Skipped Github Copilot extensions installation."
+         ;;
+      *)
+         echo "Invalid input. Skipped Github Copilot extensions installation."
+         ;;
+   esac
 }
 
 echo "Creating/Updating RobotFramework AIO runtime environment"

--- a/install/install-github-copilot-exts.sh
+++ b/install/install-github-copilot-exts.sh
@@ -1,27 +1,80 @@
 #!/bin/bash
 
-publisher="GitHub"
-declare -A extensions
-extensions=(
+VSCODIUM="$RobotVsCode/bin/codium"
+REQUIRED_VERSION=1.90.2
+
+PUBLISHER="GitHub"
+declare -A EXTENSIONS
+EXTENSIONS=(
     ["copilot-chat"]="0.16.1"
     ["copilot"]="1.212.0"
 )
 
-for extension in "${!extensions[@]}"; do
-   version="${extensions[$extension]}"
+# verify installation of VsCodium and its version
+if ! command -v "$VSCODIUM" &> /dev/null; then
+   echo "VSCodium for RobotFramework is not installed."
+   exit 1
+fi
 
-   echo "Processing $publisher.$extension, version $version"
+installed_version=$($VSCODIUM --version | head -n 1)
+
+if [ "$installed_version" != "$REQUIRED_VERSION" ]; then
+   echo "Installed VSCodium version is ${installed_version} different from expected version ${REQUIRED_VERSION}."
+   exit 1
+fi
+
+# verify Github Copilot extension installation status
+for extension in "${!EXTENSIONS[@]}"; do
+   version="${EXTENSIONS[$extension]}"
+
+   extension_info=$("$VSCODIUM" --list-extensions --show-versions | grep ".$extension@")
+   if [ -z "$extension_info" ]; then
+      echo "Extension $extension is not installed."
+   else
+      installed_ext_version=$(echo "$extension_info" | awk -F '@' '{print $2}')
+      if [ "${installed_ext_version}" != "${version}" ]; then
+         echo "Extension $extension version $installed_ext_version is installed. Reininstall it with version $version"
+      else
+         echo "Extension $extension version $installed_ext_version is already installed"
+         continue
+      fi
+   fi
+
+   echo "Processing $PUBLISHER.$extension, version $version"
 
    # Construct the download URL
-   url="https://${publisher}.gallery.vsassets.io/_apis/public/gallery/publisher/${publisher}/extension/${extension}/${version}/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
-#    url="https://marketplace.visualstudio.com/_apis/public/gallery/publishers/${publisher}/vsextensions/${extension}/${version}/vspackage"
+   url="https://${PUBLISHER}.gallery.vsassets.io/_apis/public/gallery/PUBLISHER/${PUBLISHER}/extension/${extension}/${version}/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
+#    url="https://marketplace.visualstudio.com/_apis/public/gallery/PUBLISHERs/${PUBLISHER}/vsEXTENSIONS/${extension}/${version}/vspackage"
    
-   # Download the VSIX file
-   curl -L -k "$url" -o "${publisher}.${extension}-${version}.vsix" 
+   # download the VSIX file
+	retry_counter=0
+	max_retries=5
+	success=false
+   while [[ "$retry_counter" -lt "$max_retries" && "$success" == "false" ]];do
+      curl -L -k "$url" -o "$TMP/${PUBLISHER}.${extension}-${version}.vsix" 
+      if [ $? -eq 0 ]; then
+         success=true
+         echo "Extension ${PUBLISHER}.${extension}-${version} downloaded successfully."
+      else
+         ((retry_counter++))
+         echo "Failed to download extension ${PUBLISHER}.${extension}-${version} (attempt: $retry_counter)."
+         sleep 1
+      fi
+   done
+   if [ "$success" == "false" ]; then
+		echo "Could not download extension ${PUBLISHER}.${extension}-${version} after $max_retries attempts"
+      exit 1
+	fi
 
-   # Install the extension using VSCode
-   $RobotVsCode/bin/codium --install-extension "${publisher}.${extension}-${version}.vsix"
+   # install the extension using VSCodium
+   $VSCODIUM --install-extension "$TMP/${PUBLISHER}.${extension}-${version}.vsix"
+   if [ $? -eq 0 ]; then
+      echo "Extension ${PUBLISHER}.${extension}-${version} installed successfully."
+   else
+      echo "Failed to install extension ${PUBLISHER}.${extension}-${version}."
+      exit 1
+   fi
 
-   # Cleanup the downloaded VSIX file
-   rm "${publisher}.${extension}-${version}.vsix" 
+   # clean the downloaded VSIX file
+   rm "$TMP/${PUBLISHER}.${extension}-${version}.vsix" 
 done

--- a/install/install-github-copilot-exts.sh
+++ b/install/install-github-copilot-exts.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+. /opt/rfwaio/linux/set_robotenv.sh
 
 VSCODIUM="$RobotVsCode/bin/codium"
 REQUIRED_VERSION=1.90.2
@@ -9,6 +10,8 @@ EXTENSIONS=(
     ["copilot-chat"]="0.16.1"
     ["copilot"]="1.212.0"
 )
+
+TMP=/tmp
 
 # verify installation of VsCodium and its version
 if ! command -v "$VSCODIUM" &> /dev/null; then

--- a/install/install-github-copilot-exts.sh
+++ b/install/install-github-copilot-exts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VSCODIUM="$RobotVsCode/bin/codium --user-data-dir=$RobotVsCode/data"
+VSCODIUM="$RobotVsCode/bin/codium"
 REQUIRED_VERSION=1.90.2
 
 PUBLISHER="GitHub"
@@ -15,12 +15,12 @@ USER_TMP="$HOME/tmp"
 mkdir -p "$USER_TMP"
 
 # verify installation of VsCodium and its version
-if ! command -v "$RobotVsCode/bin/codium" &> /dev/null; then
+if ! command -v "$VSCODIUM" &> /dev/null; then
    echo "VSCodium for RobotFramework is not installed."
    exit 1
 fi
 
-installed_version=$($VSCODIUM --version | head -n 1)
+installed_version=$("$VSCODIUM" --version --user-data-dir=$RobotVsCode/data | head -n 1)
 
 if [ "$installed_version" != "$REQUIRED_VERSION" ]; then
    echo "Installed VSCodium version is ${installed_version} different from expected version ${REQUIRED_VERSION}."
@@ -31,7 +31,7 @@ fi
 for extension in "${!EXTENSIONS[@]}"; do
    version="${EXTENSIONS[$extension]}"
 
-   extension_info=$($VSCODIUM --list-extensions --show-versions | grep ".$extension@")
+   extension_info=$("$VSCODIUM" --list-extensions --show-versions --user-data-dir=$RobotVsCode/data | grep ".$extension@")
    if [ -z "$extension_info" ]; then
       echo "Extension $extension is not installed."
    else
@@ -71,7 +71,7 @@ for extension in "${!EXTENSIONS[@]}"; do
 	fi
 
    # install the extension using VSCodium
-   $VSCODIUM --install-extension "$USER_TMP/${PUBLISHER}.${extension}-${version}.vsix"
+   "$VSCODIUM" --install-extension "$USER_TMP/${PUBLISHER}.${extension}-${version}.vsix" --user-data-dir=$RobotVsCode/data
    if [ $? -eq 0 ]; then
       echo "Extension ${PUBLISHER}.${extension}-${version} is installed successfully."
    else
@@ -80,5 +80,9 @@ for extension in "${!EXTENSIONS[@]}"; do
    fi
 
    # clean the downloaded VSIX file
-   rm "$USER_TMP/${PUBLISHER}.${extension}-${version}.vsix" 
+   rm "$USER_TMP/${PUBLISHER}.${extension}-${version}.vsix"
+
+   echo
+   echo "Please refer to the following article to get a GitHub Copilot license or subscription:"
+   echo "$PLACEHOLDER_REF_URL"
 done

--- a/install/install-github-copilot-exts.sh
+++ b/install/install-github-copilot-exts.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+publisher="GitHub"
+declare -A extensions
+extensions=(
+    ["copilot-chat"]="0.16.1"
+    ["copilot"]="1.212.0"
+)
+
+for extension in "${!extensions[@]}"; do
+   version="${extensions[$extension]}"
+
+   echo "Processing $publisher.$extension, version $version"
+
+   # Construct the download URL
+   url="https://${publisher}.gallery.vsassets.io/_apis/public/gallery/publisher/${publisher}/extension/${extension}/${version}/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
+#    url="https://marketplace.visualstudio.com/_apis/public/gallery/publishers/${publisher}/vsextensions/${extension}/${version}/vspackage"
+   
+   # Download the VSIX file
+   curl -L -k "$url" -o "${publisher}.${extension}-${version}.vsix" 
+
+   # Install the extension using VSCode
+   $RobotVsCode/bin/codium --install-extension "${publisher}.${extension}-${version}.vsix"
+
+   # Cleanup the downloaded VSIX file
+   rm "${publisher}.${extension}-${version}.vsix" 
+done

--- a/scripts/RobotFrameworkSetup.iss
+++ b/scripts/RobotFrameworkSetup.iss
@@ -551,7 +551,7 @@ begin
   InstructionMemo.ScrollBars := ssVertical;
   InstructionMemo.Cursor := crArrow;
   InstructionMemo.Text := '1. Open Git Bash or any other bash-compatible terminal.'#13#10#13#10+
-                          '2. Run the script provided to install GitHub Copilot extension.'#13#10#13#10+
+                          '2. Run the following bash script to install GitHub Copilot extension:'#13#10+
                           '    '+ ScriptPath
 
 end;

--- a/scripts/RobotFrameworkSetup.iss
+++ b/scripts/RobotFrameworkSetup.iss
@@ -108,6 +108,7 @@ Source: "R:\robotframework-selftest\*"; Excludes: ".git,.github"; DestDir: {app}
 
 ;Visual Studio Code installation
 Source: "R:\robotvscode\*"; Excludes: ".git,logs"; DestDir: {app}\robotvscode; Flags: ignoreversion recursesubdirs createallsubdirs; Permissions: everyone-full;
+Source: ..\install\install-github-copilot-exts.sh; DestDir: {app}\robotvscode; Flags: ignoreversion; Permissions: everyone-full;
 
 ;tools installation
 Source: "..\config\tools\*"; Excludes: ".git,*.pyc"; DestDir: {app}\tools; Flags: ignoreversion recursesubdirs createallsubdirs; Permissions: everyone-full;
@@ -242,6 +243,10 @@ var
   ProjectPage : TWizardPage;
   ProjectListBox: TNewListBox;
   PreviousUserDataDir: String;
+  InfoAfterPage: TWizardPage;
+  InstructionLabel: TLabel;
+  InstructionMemo: TMemo;
+  ScriptPath: string;
 
 //
 // Maps a given ListPosition to a fix project index
@@ -522,6 +527,32 @@ begin
   //initialize user data directory page with last directory
   UsrDataDirPage.Values[0] := GetPreviousData('UsrDataDir',ExpandConstant('{sd}\RobotTest'));
   PreviousUserDataDir := GetPreviousData('UsrDataDir',ExpandConstant(''));
+
+  //Notice for user who want to use Github Copilot extensions
+  InfoAfterPage := CreateCustomPage(wpInfoAfter, 'GitHub Copilot extension for VsCodium', 'The GitHub Copilot extension does not come pre-installed with VsCodium for RobotFramework');
+
+  InstructionLabel := TLabel.Create(WizardForm);
+  InstructionLabel.Parent := InfoAfterPage.Surface;
+  InstructionLabel.Caption := 'Please follow these steps to install Github Copilot extension for VsCodium:';
+  InstructionLabel.AutoSize := True;
+  InstructionLabel.Top := ScaleY(0);
+  InstructionLabel.Width := InfoAfterPage.SurfaceWidth;
+
+  // Create the memo for the Instruction
+  ScriptPath := WizardDirValue + '\robotvscode\install-github-copilot-exts.sh';
+  InstructionMemo := TMemo.Create(WizardForm);
+  InstructionMemo.Parent := InfoAfterPage.Surface;
+  InstructionMemo.Top := WizardForm.ReadyMemo.Top; 
+  InstructionMemo.Width := WizardForm.ReadyMemo.Width;
+  InstructionMemo.Height := WizardForm.ReadyMemo.Height;
+  InstructionMemo.Color := WizardForm.ReadyMemo.Color;
+  InstructionMemo.Font := WizardForm.ReadyMemo.Font;
+  InstructionMemo.ReadOnly := True;
+  InstructionMemo.ScrollBars := ssVertical;
+  InstructionMemo.Cursor := crArrow;
+  InstructionMemo.Text := '1. Open Git Bash or any other bash-compatible terminal.'#13#10#13#10+
+                          '2. Run the script provided to install GitHub Copilot extension.'#13#10#13#10+
+                          '    '+ ScriptPath
 
 end;
 


### PR DESCRIPTION
Hi Thomas,

This PR added the script and Github Copilot related information for end-user to install and use this extension with Vscodium.

Users are guided to execute the script to install this extension in installation log (for debian package) or Setup Wizard page (before the finish installation page on Windows).
Users can copy that path file for executing the extension installation.

Installation script is updated to verify the installation (status, version incompatible, ...) and provide the link for the subscription/license (will be changed bases on BIOS or OSS version).

Please review and give your feeling about this implementation.

Thank you,
Ngoan