### PR TITLE
correct link in release_info html file

### DIFF
--- a/tools/release_info/release_main_info.json
+++ b/tools/release_info/release_main_info.json
@@ -812,7 +812,7 @@ Feel free to contact us when you use or intend to use **RobotFramework AIO**. We
                                   "",  "https://github.com/test-fullautomation/RobotFramework_AIO/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###,###INTERMEDIATE_LABELS###; merged pull-requests; RobotFramework_AIO (build)",
                                       "https://github.com/test-fullautomation/testresultwebapp/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###,###INTERMEDIATE_LABELS###; merged pull-requests; testresultwebapp",
                                       "https://github.com/test-fullautomation/vscode-jsonp/pulls?q=is%3Apr+is%3Aclosed+label%3A###LABEL###,###INTERMEDIATE_LABELS###; merged pull-requests; vscode-jsonp",
-                                  "",  "https://gitlab-apertispro.boschdevcloud.com/robotframework-aio/main/build/-/merge_requests?scope=all&utf8=%E2%9C%93&state=merged&milestone_title###LABEL###,###INTERMEDIATE_LABELS###; merged pull-requests; Gitlab build and CI"
+                                  "",  "https://gitlab-apertispro.boschdevcloud.com/robotframework-aio/main/build/-/merge_requests?scope=all&utf8=%E2%9C%93&state=merged&milestone_title=###LABEL###; merged pull-requests; Gitlab build and CI"
                                     ]
                        },
              


### PR DESCRIPTION
Hi Thomas,

This PR correct link issue in release_info file as my email.

Currently, Gitlab does not support to filter multiple milestones or labels (list value or OR conditions in search), so that I correct the link to remove intermediate versions. 

Regarding to the links to download OSS versions, they are pointed to internal share folder but I saw that you also placed the OSS versions there. So, I keep that link.
Please let me know in case you want to change it to point to Github Release Asset.

Thank you,
Ngoan