### PR TITLE
fix incompatible issue of VsCodium Extensions

### DIFF
--- a/install/vscode_requirement.csv
+++ b/install/vscode_requirement.csv
@@ -1,4 +1,4 @@
-ms-python,python,2022.4.1
+ms-python,python,2024.10.0
 robocorp,robotframework-lsp,1.11.0
 xabikos,JavaScriptSnippets,1.8.0
 redhat,vscode-xml,0.18.1


### PR DESCRIPTION
Hi Thomas,

This PR update the version of `Python` extension in VsCodium to fix issue with `Copilot` extension.

Thank you,
Ngoan