### PR TITLE
Python Debug extension is required for pre installed vscodium

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -47,6 +47,7 @@ if [ "$UNAME" == "Linux" ] ; then
 	os=linux
 	os_short=linux
 	arch=
+	platform=linux-x64
 	download_python_url=https://github.com/indygreg/python-build-standalone/releases/download/20210303/cpython-3.9.2-x86_64-unknown-linux-gnu-pgo-20210303T0937.tar.zst
 	download_vscode_url=https://github.com/VSCodium/vscodium/releases/download/${VERSION_VSCODIUM}/VSCodium-linux-x64-${VERSION_VSCODIUM}.tar.gz
 
@@ -60,6 +61,7 @@ elif [[ "$UNAME" == CYGWIN* || "$UNAME" == MINGW* ]] ; then
 	os=windows
 	os_short=win
 	arch=-x64
+	platform=win32-x64
 	download_python_url=https://github.com/indygreg/python-build-standalone/releases/download/20221220/cpython-3.9.16+20221220-x86_64-pc-windows-msvc-shared-install_only.tar.gz
 	download_vscode_url=https://github.com/VSCodium/vscodium/releases/download/${VERSION_VSCODIUM}/VSCodium-win32-x64-${VERSION_VSCODIUM}.zip
 	download_pandoc_url=https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-windows-x86_64.zip
@@ -179,6 +181,9 @@ function packaging_vscode() {
 	do
 		version=$(echo $version|tr -d '\n'|tr -d '\r')
 		url=https://open-vsx.org/api/${publisher}/${name}/${version}/file/${publisher}.${name}-${version}.vsix
+		if [ "$name" == "debugpy" ]; then
+			url=https://open-vsx.org/api/${publisher}/${name}/${platform}/${version}/file/${publisher}.${name}-${version}@${platform}.vsix
+		fi
 		our_url=https://github.com/${publisher}/${name}/releases/download/${name}-${version}/${name}.vsix
 
 		if [[ -n "$name" ]]; then

--- a/install/vscode_requirement.csv
+++ b/install/vscode_requirement.csv
@@ -5,3 +5,4 @@ redhat,vscode-xml,0.18.1
 tomoki1207,pdf,1.2.2
 jebbs,plantuml,2.17.5
 hediet,vscode-drawio,1.6.6
+ms-python,debugpy,2024.8.0


### PR DESCRIPTION
Hi Thomas,

`Debugpy`, which is used for debugging python, has been separated from `Python` extension since [v2024.6.0](https://github.com/microsoft/vscode-python/releases/tag/v2024.6.0) as new extension `Python Debugger`.

This PR adds that `Python Debugger` extension for VsCodium.

Thank you,
Ngoan
