### PR TITLE
replace robotframework-lsp vscodium extension by RobotCode

### DIFF
--- a/config/RobotTest/testcases/.vscode/launch.json
+++ b/config/RobotTest/testcases/.vscode/launch.json
@@ -5,13 +5,13 @@
   "version"        : "0.2.0",
   "configurations" : [
     {
-      "type"     : "robotframework-lsp",
-      "name"     : "Robot Framework: Launch .robot file",
+      "type"     : "robotcode",
+      "name"     : "Robot Framework: Run .robot file",
       "request"  : "launch",
       "cwd"      : "${workspaceFolder}",
       "target"   : "${file}",
-      "terminal" : "integrated",
       "env"      : {},
+      "console"  : "integratedTerminal",
       "args"     : ["-T",
                     "-d", "${workspaceFolder}${pathSeparator}..${pathSeparator}logfiles",
                     "-b", "debug${pathSeparator}${fileBasenameNoExtension}.log",

--- a/config/robotframework_aio/release_items_Robotframework_AIO.json
+++ b/config/robotframework_aio/release_items_Robotframework_AIO.json
@@ -220,8 +220,9 @@
 
 **VSCodium Package**
 
-* Replace `robotframework-lsp <https://github.com/robocorp/robotframework-lsp>`_ extension 
-  by `RobotCode <https://robotcode.io/>`_ extension
+* `robotframework-lsp <https://github.com/robocorp/robotframework-lsp>`_ extension is now deprecated,
+  and the `RobotCode <https://robotcode.io/>`_ extension is used as its replacement.
+  Please refer to `this issue <https://github.com/robocorp/robotframework-lsp/issues/1051>`_ for more detail.
 "
                               ]
                  }

--- a/config/robotframework_aio/release_items_Robotframework_AIO.json
+++ b/config/robotframework_aio/release_items_Robotframework_AIO.json
@@ -214,9 +214,14 @@
                               ],
                               "0.13.1." : [
 "
-**Robot Framework**
+**Robot Framework pipeline**
 
 * Added test coverage to ensure functionality and improve overall code reliability
+
+**VSCodium Package**
+
+* Replace `robotframework-lsp <https://github.com/robocorp/robotframework-lsp>`_ extension 
+  by `RobotCode <https://robotcode.io/>`_ extension
 "
                               ]
                  }

--- a/config/robotvscode/launch/version-1/launch.json
+++ b/config/robotvscode/launch/version-1/launch.json
@@ -22,12 +22,12 @@
   "version"        : "0.2.0",
   "configurations" : [
     {
-      "type"     : "robotframework-lsp",
+      "type"     : "robotcode",
       "name"     : "Robot Framework: Launch .robot file",
       "request"  : "launch",
       "cwd"      : "${workspaceFolder}",
       "target"   : "${file}",
-      "terminal" : "integrated",
+      "console"  : "integratedTerminal",
       "env"      : {},
       "args"     : ["-d", "${workspaceFolder}${pathSeparator}reports",
                     "-b", "${fileBasenameNoExtension}.log",

--- a/config/robotvscode/launch/version-2/launch.json
+++ b/config/robotvscode/launch/version-2/launch.json
@@ -22,12 +22,12 @@
   "version"        : "0.2.0",
   "configurations" : [
     {
-      "type"     : "robotframework-lsp",
+      "type"     : "robotcode",
       "name"     : "Robot Framework: Launch .robot file",
       "request"  : "launch",
       "cwd"      : "${workspaceFolder}",
       "target"   : "${file}",
-      "terminal" : "integrated",
+      "console"  : "integratedTerminal",
       "env"      : {},
       "args"     : ["-T",
                     "-d", "${workspaceFolder}${pathSeparator}reports${pathSeparator}${input:targetName}_${fileBasenameNoExtension}",

--- a/install/README.md
+++ b/install/README.md
@@ -189,29 +189,20 @@ Finally, issue the command:
 ```
 ## Install extension in AIO package
 This section provides the info for installing Visual Studio Code extensions using a **install.sh** script. Refer: [issues 191](https://github.com/test-fullautomation/RobotFramework_AIO/issues/191#issuecomment-2031051647)
-* All extensions can be installed through https://open-vsx.org/
 
-| Publisher           | Name                | Version |
-|---------------------|---------------------|---------|
-| ms-python           | python              | 2022.4.1|
-| robocorp            | robotframework-lsp  | 1.11.0  |
-| xabikos             | JavaScriptSnippets  | 1.8.0   |
-| redhat              | vscode-xml          | 0.18.1  |
-| tomoki1207          | pdf                 | 1.2.2   |
-| jebbs               | plantuml            | 2.17.5  |
-| hediet              | vscode-drawio       | 1.6.6   |
+Below extensions can be installed through https://open-vsx.org/
 
-* Specify the extension from the test-fullautomation owner.
+| Publisher           | Name                | Version   |
+|---------------------|---------------------|-----------|
+| ms-python           | python              | 2024.10.0 |
+| d-biehl             | robotcode           | 0.93.1    |
+| xabikos             | JavaScriptSnippets  | 1.8.0     |
+| redhat              | vscode-xml          | 0.18.1    |
+| tomoki1207          | pdf                 | 1.2.2     |
+| jebbs               | plantuml            | 2.17.5    |
+| hediet              | vscode-drawio       | 1.6.6     |
+| ms-python           | debugpy             | 2024.8.0  |
 
-| Publisher           | Extension           | Version |
-|---------------------|---------------------|---------|
-| ms-python           | python              | 2022.4.1|
-| test-fullautomation | robotframework-lsp  | 1.11.1  |
-| xabikos             | JavaScriptSnippets  | 1.8.0   |
-| redhat              | vscode-xml          | 0.18.1  |
-| tomoki1207          | pdf                 | 1.2.2   |
-| jebbs               | plantuml            | 2.17.5  |
-| hediet              | vscode-drawio       | 1.6.6   |
 
 ## About
 

--- a/install/vscode_requirement.csv
+++ b/install/vscode_requirement.csv
@@ -1,5 +1,5 @@
 ms-python,python,2024.10.0
-robocorp,robotframework-lsp,1.11.0
+d-biehl,robotcode,0.93.1
 xabikos,JavaScriptSnippets,1.8.0
 redhat,vscode-xml,0.18.1
 tomoki1207,pdf,1.2.2


### PR DESCRIPTION
Hi Thomas,

This PR replace the `robotframework-lsp vscodium` extension by `RobotCode`.
I have also updated related  `launch.json` files properly due to this replacement.

Thank you,
Ngoan