### PR TITLE
add RobotCode setting: Robocop linting excluded rules and debug timestamp

### DIFF
--- a/config/robotvscode/data/user-data/User/settings.json
+++ b/config/robotvscode/data/user-data/User/settings.json
@@ -66,6 +66,10 @@
     "timeline.excludeSources": [],
     "extensions.autoUpdate": false,
     "update.mode": "none",
+    "robotcode.debug.outputTimestamps": true,
+    "robotcode.robocop.exclude": [
+        "0301,0302,0305,0309,0310,0509,0602,0605,0606,0607,0702,0704,0907,0908"
+    ],
     "rst.preview.pythonPath": "{RobotPythonPath}/python3",
     // Other specific settings
 }


### PR DESCRIPTION
Hi Thomas,

This PR update the VsCodium setting for RobotCode extension:
- The robocop's excluded rules are added to avoid linting issue
- Timestamp is enabled for `Debug Console`.

Thank you,
Ngoan