### PR TITLE
add missing release info files in Github Release

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -409,7 +409,7 @@ jobs:
         omitNameDuringUpdate: true
         prerelease: true
         name: RobotFramework AIO version ${{ env.RELEASE_VERSION }}
-        artifacts: "windows-package-original/*.exe,windows-package-extended/*.exe,linux-package-original/*.deb,linux-package-extended/*.deb,windows-aiotestlogfiles-extended/release_info_RobotFramework_AIO_*.html,windows-aiotestlogfiles-original/release_info_RobotFramework_AIO_*.html,RobotFrameworkAIO_Reference_extended/*.pdf,RobotFrameworkAIO_Reference_original/*.pdf"
+        artifacts: "windows-package-original/*.exe,windows-package-extended/*.exe,linux-package-original/*.deb,linux-package-extended/*.deb,windows-aiotestlogfiles-extended/release_info_*.html,windows-aiotestlogfiles-original/release_info_*.html,RobotFrameworkAIO_Reference_extended/*.pdf,RobotFrameworkAIO_Reference_original/*.pdf"
         bodyFile: "windows-aiotestlogfiles-extended/release_changelog.html"
 
   tag-to-publish-packges-to-pypi:


### PR DESCRIPTION
Hi Thomas,

This PR updated the missing release info html files in generating [Github Release of 0.13.1.14](https://github.com/test-fullautomation/RobotFramework_AIO/releases/tag/rel%2Faio%2F0.13.1.14).
I have changed those filenames (add `OSS`) to align with release folder but did not update the pattern to upload them to Github Release.

Thank you,
Ngoan