### PR TITLE
Remove proxy information from vscodium setting

### DIFF
--- a/config/robotvscode/data/user-data/User/settings.json
+++ b/config/robotvscode/data/user-data/User/settings.json
@@ -30,19 +30,11 @@
     "window.zoomLevel": 0,
     "editor.renderControlCharacters": false,
 
-    "http.proxy": "http://rb-proxy-apac.bosch.com:8080",
-    "https.proxy": "https://rb-proxy-apac.bosch.com:8080",
+    "http.proxy": "",
     "http.proxyAuthorization": null,
     "http.proxyStrictSSL": false,
     "editor.renderWhitespace": "all",
-    "robot.language-server.python": "${env:RobotPythonPath}/python3",
-    "robot.python.executable": "${env:RobotPythonPath}/python3",
-	"robot.lint.robocop.enabled ": true,
-    "robot.python.env": {
-    
-    },
     "python.defaultInterpreterPath": "${env:RobotPythonPath}/python3",
-    "python.pythonPath ": "${env:RobotPythonPath}/python3",
 
     "redhat.telemetry.enabled": false,
     "workbench.editorAssociations": {
@@ -63,7 +55,6 @@
     "security.workspace.trust.enabled": false,
     "security.workspace.trust.banner": "never",
     "security.workspace.trust.emptyWindow": true,
-    "timeline.excludeSources": [],
     "extensions.autoUpdate": false,
     "update.mode": "none",
     "robotcode.debug.outputTimestamps": true,

--- a/install/install.sh
+++ b/install/install.sh
@@ -159,6 +159,16 @@ function packaging_vscode() {
 	mkdir "$sourceDir/vscodium/data"
 	cp -rf "$vscodeData/data/user-data" "$sourceDir/vscodium/data/"
 
+	# add proxy configuration in vscodium setting if given
+	if [ "$VSCODIUM_PROXY" != "" ] ; then
+		vscodium_setting_file="$sourceDir/vscodium/data/user-data/User/settings.json"
+		if [[ -f "$vscodium_setting_file" ]]; then
+			sed -i -E "s|\"http.proxy\": \"\"|\"http.proxy\": \"$VSCODIUM_PROXY\"|g" "$vscodium_setting_file"
+		else
+			echo "Vscodium setting file '$vscodium_setting_file' does not exist"
+		fi
+	fi
+
 	echo "Install extension for visual codium from *.vsix files under config/robotvscode/extensions folder"
 	chmod +x "$sourceDir/vscodium/bin/codium"
 	for extfile in $vscodeData/extensions/*.vsix; do


### PR DESCRIPTION
Hi Thomas,

This PR removes proxy information from OSS packages. 
Besides, the step to configure Bosch proxy for BIOS packages.

P/s: I also removed the deprecated configurations in Vscodium `settings.json` file

Thank you,
Ngoan