### PR TITLE
temporarily fix version of setuptool to 79.0.1

### DIFF
--- a/install/python_requirements.txt
+++ b/install/python_requirements.txt
@@ -118,7 +118,7 @@ scp
 # scapy
 scipy
 # Scrapy
-setuptools
+setuptools==79.0.1
 # selenium
 # service-identity
 six

--- a/install/python_requirements_lx.txt
+++ b/install/python_requirements_lx.txt
@@ -122,7 +122,7 @@ scp
 # scapy
 scipy
 # Scrapy
-setuptools
+setuptools==79.0.1
 # selenium
 # service-identity
 six


### PR DESCRIPTION
Hi Thomas,

I provided the fixed version `79.0.1` for `setuptool` which worked with our build pipeline.

Thank you,
Ngoan