### PR TITLE
fix version of bcrypt to 4.2.1

### DIFF
--- a/install/python_requirements.txt
+++ b/install/python_requirements.txt
@@ -11,7 +11,7 @@ asciidoxy
 attrs
 # autobahn
 # Automat
-bcrypt
+bcrypt==4.2.1
 certifi
 cffi
 colorama

--- a/install/python_requirements_lx.txt
+++ b/install/python_requirements_lx.txt
@@ -8,7 +8,7 @@ attrs
 asciidoxy
 # autobahn
 # Automat
-bcrypt
+bcrypt==4.2.1
 cchardet==2.2.0a2
 certifi
 cffi


### PR DESCRIPTION
Fix version of `bcrypt`  to `4.2.1` as @milanac030988 's request