### PR TITLE
Mar3hc/feat/version check tool

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -319,7 +319,7 @@ jobs:
           ${{ runner.workspace }}/[Rr]obotframework*/**/*/testlogfiles/*
           ${{ runner.workspace }}/[Pp]ython*/**/*/testlogfiles/*
           ${{ runner.workspace }}/Robotframework_AIO/console_log.txt
-          ${{ runner.workspace }}/Robotframework_AIO/package_version_report.csv
+          ${{ runner.workspace }}/package_version_report.csv
           ${{ runner.workspace }}/[Rr]obotframework*/**/*/*/coverage_report/*
           ${{ runner.workspace }}/[Pp]ython*/**/*/*/coverage_report/*
           ${{ runner.workspace }}/[Rr]obotframework*/**/*/*/coverage_report/*
@@ -436,7 +436,7 @@ jobs:
           ${{ runner.workspace }}/**/*/aiotestlogfiles/*
           ${{ runner.workspace }}/**/*/testlogfiles/*
           ${{ runner.workspace }}/**/*/console_log.txt
-          ${{ runner.workspace }}/**/*/package_version_report.csv
+          ${{ runner.workspace }}/**/package_version_report.csv
           ${{ runner.workspace }}/**/*/*/coverage_report/*
           ${{ runner.workspace }}/release_info_RobotFramework_AIO_*.html
           ${{ runner.workspace }}/**/*/static_code_report/*

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -265,7 +265,7 @@ jobs:
       shell: bash
       run: |
         chmod +x ./install/check_external_version.sh
-        ./install/check_external_version.sh -i ./install/python_requirements.txt -v ./install/vscode_requirement.csv -o ../../package_version_report.csv
+        ./install/check_external_version.sh -i ./install/python_requirements.txt -v ./install/vscode_requirement.csv -o ../package_version_report.csv
 
     - name: Run static code analysis on Windows
       shell: bash
@@ -367,7 +367,7 @@ jobs:
     - name: Check external dependencies version
       run: |
         chmod +x ./install/check_external_version.sh
-        ./install/check_external_version.sh -i ./install/python_requirements_lx.txt -v ./install/vscode_requirement.csv -o ../../package_version_report.csv
+        ./install/check_external_version.sh -i ./install/python_requirements_lx.txt -v ./install/vscode_requirement.csv -o ../package_version_report.csv
 
     - name: Run static code analysis on Linux
       run: |

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -367,7 +367,7 @@ jobs:
     - name: Check external dependencies version
       run: |
         chmod +x ./install/check_external_version.sh
-        ./install/check_external_version.sh -i ./install/python_requirements_lx.txt ./install/vscode_requirement.csv -o package_version_report.csv
+        ./install/check_external_version.sh -i ./install/python_requirements_lx.txt -v ./install/vscode_requirement.csv -o package_version_report.csv
 
     - name: Run static code analysis on Linux
       run: |

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -265,7 +265,7 @@ jobs:
       shell: bash
       run: |
         chmod +x ./install/check_external_version.sh
-        ./install/check_external_version.sh -i ./install/python_requirements.txt -o package_version_report.csv
+        ./install/check_external_version.sh -i ./install/python_requirements.txt -v ./install/vscode_requirement.csv -o package_version_report.csv
 
     - name: Run static code analysis on Windows
       shell: bash
@@ -367,7 +367,7 @@ jobs:
     - name: Check external dependencies version
       run: |
         chmod +x ./install/check_external_version.sh
-        ./install/check_external_version.sh -i ./install/python_requirements_lx.txt -o package_version_report.csv
+        ./install/check_external_version.sh -i ./install/python_requirements_lx.txt ./install/vscode_requirement.csv -o package_version_report.csv
 
     - name: Run static code analysis on Linux
       run: |

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -261,6 +261,12 @@ jobs:
       shell: cmd
       run: ./scripts/install-windows.bat
 
+    - name: Check external dependencies version
+      shell: bash
+      run: |
+        chmod +x ./install/check_external_version.sh
+        ./install/check_external_version.sh -i ./install/check_external_version.sh -o package_version_report.csv
+
     - name: Run static code analysis on Windows
       shell: bash
       run: |
@@ -313,6 +319,7 @@ jobs:
           ${{ runner.workspace }}/[Rr]obotframework*/**/*/testlogfiles/*
           ${{ runner.workspace }}/[Pp]ython*/**/*/testlogfiles/*
           ${{ runner.workspace }}/Robotframework_AIO/console_log.txt
+          ${{ runner.workspace }}/Robotframework_AIO/package_version_report.csv
           ${{ runner.workspace }}/[Rr]obotframework*/**/*/*/coverage_report/*
           ${{ runner.workspace }}/[Pp]ython*/**/*/*/coverage_report/*
           ${{ runner.workspace }}/[Rr]obotframework*/**/*/*/coverage_report/*
@@ -356,6 +363,11 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install ./*.deb --fix-missing
+
+    - name: Check external dependencies version
+      run: |
+        chmod +x ./install/check_external_version.sh
+        ./install/check_external_version.sh -i ./install/check_external_version.sh -o package_version_report.csv
 
     - name: Run static code analysis on Linux
       run: |
@@ -424,6 +436,7 @@ jobs:
           ${{ runner.workspace }}/**/*/aiotestlogfiles/*
           ${{ runner.workspace }}/**/*/testlogfiles/*
           ${{ runner.workspace }}/**/*/console_log.txt
+          ${{ runner.workspace }}/**/*/package_version_report.csv
           ${{ runner.workspace }}/**/*/*/coverage_report/*
           ${{ runner.workspace }}/release_info_RobotFramework_AIO_*.html
           ${{ runner.workspace }}/**/*/static_code_report/*

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -265,7 +265,7 @@ jobs:
       shell: bash
       run: |
         chmod +x ./install/check_external_version.sh
-        ./install/check_external_version.sh -i ./install/check_external_version.sh -o package_version_report.csv
+        ./install/check_external_version.sh -i ./install/python_requirements.txt -o package_version_report.csv
 
     - name: Run static code analysis on Windows
       shell: bash
@@ -367,7 +367,7 @@ jobs:
     - name: Check external dependencies version
       run: |
         chmod +x ./install/check_external_version.sh
-        ./install/check_external_version.sh -i ./install/check_external_version.sh -o package_version_report.csv
+        ./install/check_external_version.sh -i ./install/python_requirements_lx.txt -o package_version_report.csv
 
     - name: Run static code analysis on Linux
       run: |

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -265,7 +265,7 @@ jobs:
       shell: bash
       run: |
         chmod +x ./install/check_external_version.sh
-        ./install/check_external_version.sh -i ./install/python_requirements.txt -v ./install/vscode_requirement.csv -o package_version_report.csv
+        ./install/check_external_version.sh -i ./install/python_requirements.txt -v ./install/vscode_requirement.csv -o ../../package_version_report.csv
 
     - name: Run static code analysis on Windows
       shell: bash
@@ -367,7 +367,7 @@ jobs:
     - name: Check external dependencies version
       run: |
         chmod +x ./install/check_external_version.sh
-        ./install/check_external_version.sh -i ./install/python_requirements_lx.txt -v ./install/vscode_requirement.csv -o package_version_report.csv
+        ./install/check_external_version.sh -i ./install/python_requirements_lx.txt -v ./install/vscode_requirement.csv -o ../../package_version_report.csv
 
     - name: Run static code analysis on Linux
       run: |
@@ -436,7 +436,7 @@ jobs:
           ${{ runner.workspace }}/**/*/aiotestlogfiles/*
           ${{ runner.workspace }}/**/*/testlogfiles/*
           ${{ runner.workspace }}/**/*/console_log.txt
-          ${{ runner.workspace }}/**/package_version_report.csv
+          ${{ runner.workspace }}/package_version_report.csv
           ${{ runner.workspace }}/**/*/*/coverage_report/*
           ${{ runner.workspace }}/release_info_RobotFramework_AIO_*.html
           ${{ runner.workspace }}/**/*/static_code_report/*

--- a/install/check_external_version.sh
+++ b/install/check_external_version.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Function to display usage
+usage() {
+    echo "Usage: $0 -i <input_file> -o <output_file>"
+    echo "  -i, --input   Path to the input requirements file (e.g., python_requirements.txt)"
+    echo "  -o, --output  Path to the output CSV file (e.g., package_updates.csv)"
+    exit 1
+}
+
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -i|--input) input_file="$2"; shift ;;
+        -o|--output) output_file="$2"; shift ;;
+        *) echo "Unknown parameter: $1"; usage ;;
+    esac
+    shift
+done
+
+# Check if input and output files are provided
+if [[ -z "$input_file" || -z "$output_file" ]]; then
+    echo "Error: Both input and output files must be specified."
+    usage
+fi
+
+# Check if input file exists
+if [[ ! -f "$input_file" ]]; then
+    echo "Error: Input file '$input_file' not found."
+    exit 1
+fi
+
+# Create or clear the output CSV file
+echo "source,package_name,current_version,new_version,link_to_new_version" > "$output_file"
+
+# Function to fetch the latest version from PyPI
+get_latest_version() {
+    local package_name=$1
+    local response
+    response=$(curl -s -m 5 "https://pypi.org/pypi/$package_name/json")
+    if [[ $? -ne 0 ]]; then
+        echo "Error fetching version"
+        return
+    fi
+    # Check if response contains valid JSON and a version
+    local version
+    version=$(echo "$response" | jq -r '.info.version // empty')
+    if [[ -z "$version" ]]; then
+        echo "Not found"
+    else
+        echo "$version"
+    fi
+}
+
+# Read input file line by line
+while IFS= read -r line || [[ -n "$line" ]]; do
+    # Skip empty lines and comments
+    if [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]]; then
+        continue
+    fi
+
+    # Parse package==version using regex
+    if [[ "$line" =~ ^([a-zA-Z0-9_-]+)==([0-9a-zA-Z.]+) ]]; then
+        package_name="${BASH_REMATCH[1]}"
+        current_version="${BASH_REMATCH[2]}"
+        new_version=$(get_latest_version "$package_name")
+
+        # Log errors to console
+        if [[ "$new_version" == "Not found" ]]; then
+            echo "Error: Package '$package_name' not found on PyPI."
+        elif [[ "$new_version" == "Error fetching version" ]]; then
+            echo "Error: Failed to fetch version for package '$package_name' from PyPI."
+        elif [[ "$new_version" =~ ^[0-9][0-9a-zA-Z.]*$ ]]; then
+            # Basic validation: ensure new_version starts with a digit
+            :
+        else
+            echo "Error: Invalid version format for package '$package_name' (current: $current_version)."
+            new_version="Invalid version format"
+        fi
+
+        # Write to CSV
+        echo "pypi,$package_name,$current_version,$new_version,https://pypi.org/project/$package_name/" >> "$output_file"
+    fi
+done < "$input_file"

--- a/install/check_external_version.sh
+++ b/install/check_external_version.sh
@@ -31,7 +31,7 @@ if [[ ! -f "$input_file" ]]; then
 fi
 
 # Create or clear the output CSV file
-echo "source,package_name,current_version,new_version,link_to_new_version" > "$output_file"
+printf "%-5s,%-30s,%15s,%15s,%s\n" "source" "package_name" "current_version" "new_version" "link_to_new_version" > "$output_file"
 
 # Function to fetch the latest version from PyPI
 get_latest_version() {
@@ -79,6 +79,6 @@ while IFS= read -r line || [[ -n "$line" ]]; do
         fi
 
         # Write to CSV
-        echo "pypi,$package_name,$current_version,$new_version,https://pypi.org/project/$package_name/" >> "$output_file"
+        printf "%-5s,%-30s,%15s,%15s,%s\n" "pypi" "$package_name" "$current_version" "$new_version" "https://pypi.org/project/$package_name/" >> "$output_file
     fi
 done < "$input_file"

--- a/install/check_external_version.sh
+++ b/install/check_external_version.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
+mypath=$(realpath $(dirname $0))
+
+# Load Version definition of package tools
+source $mypath/versions.conf
+
 # Function to display usage
 usage() {
-    echo "Usage: $0 -i <input_file> -o <output_file>"
-    echo "  -i, --input   Path to the input requirements file (e.g., python_requirements.txt)"
-    echo "  -o, --output  Path to the output CSV file (e.g., package_updates.csv)"
+    echo "Usage: $0 -i <input_file> -o <output_file> [-v <vscode_input_file>]"
+    echo "  -i, --input        Path to the Python requirements file (e.g., python_requirements.txt)"
+    echo "  -v, --vscode-input Path to the VS Code extensions CSV file (e.g., vscode_requirements.csv, optional)"
+    echo "  -o, --output       Path to the output CSV file (e.g., package_updates.csv)"
     exit 1
 }
 
@@ -12,6 +18,7 @@ usage() {
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         -i|--input) input_file="$2"; shift ;;
+        -v|--vscode-input) vscode_input_file="$2"; shift ;;
         -o|--output) output_file="$2"; shift ;;
         *) echo "Unknown parameter: $1"; usage ;;
     esac
@@ -30,11 +37,17 @@ if [[ ! -f "$input_file" ]]; then
     exit 1
 fi
 
-# Create or clear the output CSV file
+# Check if vscode input file exists (if provided)
+if [[ -n "$vscode_input_file" && ! -f "$vscode_input_file" ]]; then
+    echo "Error: VS Code input file '$vscode_input_file' not found."
+    exit 1
+fi
+
+# Create or clear the output CSV file with header
 printf "%-5s,%-30s,%15s,%15s,%s\n" "source" "package_name" "current_version" "new_version" "link_to_new_version" > "$output_file"
 
 # Function to fetch the latest version from PyPI
-get_latest_version() {
+get_latest_pypi_version() {
     local package_name=$1
     local response
     response=$(curl -s -m 5 "https://pypi.org/pypi/$package_name/json")
@@ -52,7 +65,72 @@ get_latest_version() {
     fi
 }
 
-# Read input file line by line
+# Function to check VSCodium version
+check_vscodium_version() {
+    local package_name="vscodium"
+    local new_version
+    local link="https://github.com/VSCodium/vscodium/releases"
+
+    # Fetch latest version from GitHub releases
+    local response
+    response=$(curl -s -m 5 "https://api.github.com/repos/VSCodium/vscodium/releases/latest")
+    if [[ $? -ne 0 ]]; then
+        new_version="Error fetching version"
+        echo "Error: Failed to fetch latest version VSCodium from GitHub."
+    else
+        new_version=$(echo "$response" | jq -r '.tag_name // empty' | sed 's/^v//')
+        if [[ -z "$new_version" ]]; then
+            new_version="Not found"
+            echo "Error: Latest VSCodium version not found on GitHub."
+        fi
+    fi
+
+    # Write to CSV with right-aligned fields
+    printf "%-5s,%-30s,%15s,%15s,%s\n" "github" "$package_name" "$VERSION_VSCODIUM" "$new_version" "$link" >> "$output_file"
+}
+
+# Function to check VS Code/VSCodium extensions
+check_vscode_extensions() {
+    local vscode_input_file=$1
+    # Read CSV line by line (no header assumed)
+    while IFS=',' read -r publisher extension current_version || [[ -n "$publisher" ]]; do
+        # Skip empty or incomplete lines
+        if [[ -z "$publisher" || -z "$extension" || -z "$current_version" ]]; then
+            continue
+        fi
+
+        # Construct package_name as publisher.extension
+        package_name="$publisher.$extension"
+        link="https://marketplace.visualstudio.com/items?itemName=$package_name"
+
+        # Fetch latest version from VS Code Marketplace
+        local response
+        response=$(curl -s -m 5 "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/$publisher/vsextensions/$extension/latest/vspackage")
+        if [[ $? -ne 0 ]]; then
+            new_version="Error fetching version"
+            echo "Error: Failed to fetch latest version for extension '$package_name' from VS Code Marketplace."
+        else
+            new_version=$(echo "$response" | jq -r '.version // empty')
+            if [[ -z "$new_version" ]]; then
+                new_version="Not found"
+                echo "Error: Extension '$package_name' not found on VS Code Marketplace."
+            fi
+        fi
+
+        # Write to CSV
+        printf "%-5s,%-30s,%15s,%15s,%s\n" "vscode_marketplace" "$package_name" "$current_version" "$new_version" "$link" >> "$output_file"
+    done < "$vscode_input_file"
+}
+
+# Check VSCodium version and add to CSV
+check_vscodium_version
+
+# Check VS Code extensions if input file is provided
+if [[ -n "$vscode_input_file" ]]; then
+    check_vscode_extensions "$vscode_input_file"
+fi
+
+# Read Python requirements file line by line
 while IFS= read -r line || [[ -n "$line" ]]; do
     # Skip empty lines and comments
     if [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]]; then
@@ -63,7 +141,7 @@ while IFS= read -r line || [[ -n "$line" ]]; do
     if [[ "$line" =~ ^([a-zA-Z0-9_-]+)==([0-9a-zA-Z.]+) ]]; then
         package_name="${BASH_REMATCH[1]}"
         current_version="${BASH_REMATCH[2]}"
-        new_version=$(get_latest_version "$package_name")
+        new_version=$(get_latest_pypi_version "$package_name")
 
         # Log errors to console
         if [[ "$new_version" == "Not found" ]]; then
@@ -78,7 +156,7 @@ while IFS= read -r line || [[ -n "$line" ]]; do
             new_version="Invalid version format"
         fi
 
-        # Write to CSV
+        # Write to CSV with right-aligned fields
         printf "%-5s,%-30s,%15s,%15s,%s\n" "pypi" "$package_name" "$current_version" "$new_version" "https://pypi.org/project/$package_name/" >> "$output_file"
     fi
 done < "$input_file"

--- a/install/check_external_version.sh
+++ b/install/check_external_version.sh
@@ -31,6 +31,10 @@ if [[ -z "$input_file" || -z "$output_file" ]]; then
     usage
 fi
 
+if [[ -n "$output_file" ]]; then
+    output_file=$(realpath "$output_file" 2>/dev/null || echo "$output_file")
+fi
+
 # Check if input file exists
 if [[ ! -f "$input_file" ]]; then
     echo "Error: Input file '$input_file' not found."
@@ -165,3 +169,5 @@ while IFS= read -r line || [[ -n "$line" ]]; do
         printf "%-5s,%-30s,%15s,%15s,%s\n" "pypi" "$package_name" "$current_version" "$new_version" "https://pypi.org/project/$package_name/" >> "$output_file"
     fi
 done < "$input_file"
+
+echo "Report file saved in: $output_file"

--- a/install/check_external_version.sh
+++ b/install/check_external_version.sh
@@ -79,6 +79,6 @@ while IFS= read -r line || [[ -n "$line" ]]; do
         fi
 
         # Write to CSV
-        printf "%-5s,%-30s,%15s,%15s,%s\n" "pypi" "$package_name" "$current_version" "$new_version" "https://pypi.org/project/$package_name/" >> "$output_file
+        printf "%-5s,%-30s,%15s,%15s,%s\n" "pypi" "$package_name" "$current_version" "$new_version" "https://pypi.org/project/$package_name/" >> "$output_file"
     fi
 done < "$input_file"

--- a/install/check_external_version.sh
+++ b/install/check_external_version.sh
@@ -89,7 +89,6 @@ check_vscodium_version() {
     printf "%-5s,%-30s,%15s,%15s,%s\n" "github" "$package_name" "$VERSION_VSCODIUM" "$new_version" "$link" >> "$output_file"
 }
 
-# Function to check VS Code/VSCodium extensions
 check_vscode_extensions() {
     local vscode_input_file=$1
     # Read CSV line by line (no header assumed)
@@ -103,21 +102,27 @@ check_vscode_extensions() {
         package_name="$publisher.$extension"
         link="https://marketplace.visualstudio.com/items?itemName=$package_name"
 
-        # Fetch latest version from VS Code Marketplace
+        # Fetch latest version from Open VSX Registry
         local response
-        response=$(curl -s -m 5 "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/$publisher/vsextensions/$extension/latest/vspackage")
+        response=$(curl -s -m 5 "https://open-vsx.org/api/$publisher/$extension")
         if [[ $? -ne 0 ]]; then
             new_version="Error fetching version"
-            echo "Error: Failed to fetch latest version for extension '$package_name' from VS Code Marketplace."
+            echo "Error: Failed to fetch latest version for extension '$package_name' from Open VSX Registry."
         else
-            new_version=$(echo "$response" | jq -r '.version // empty')
-            if [[ -z "$new_version" ]]; then
-                new_version="Not found"
-                echo "Error: Extension '$package_name' not found on VS Code Marketplace."
+            # Check if response is valid JSON
+            if echo "$response" | jq -e . >/dev/null 2>&1; then
+                new_version=$(echo "$response" | jq -r '.version // empty')
+                if [[ -z "$new_version" ]]; then
+                    new_version="Not found"
+                    echo "Error: Extension '$package_name' not found on Open VSX Registry."
+                fi
+            else
+                new_version="Invalid response"
+                echo "Error: Invalid response for extension '$package_name' from Open VSX Registry."
             fi
         fi
 
-        # Write to CSV
+        # Write to CSV with right-aligned fields, using current_version from file
         printf "%-5s,%-30s,%15s,%15s,%s\n" "vscode_marketplace" "$package_name" "$current_version" "$new_version" "$link" >> "$output_file"
     done < "$vscode_input_file"
 }

--- a/install/check_external_version.sh
+++ b/install/check_external_version.sh
@@ -147,9 +147,11 @@ while IFS= read -r line || [[ -n "$line" ]]; do
     fi
 
     # Parse package==version using regex
-    if [[ "$line" =~ ^([a-zA-Z0-9_-]+)==([0-9a-zA-Z.]+) ]]; then
+    if [[ "$line" =~ ^([a-zA-Z0-9_-]+)(\[.*\])?(==|>=|<=|!=|~=)([0-9a-zA-Z.]+) ]]; then
         package_name="${BASH_REMATCH[1]}"
-        current_version="${BASH_REMATCH[2]}"
+        extras="${BASH_REMATCH[2]}"
+        version_specifier="${BASH_REMATCH[3]}"
+        current_version="${BASH_REMATCH[4]}"
         new_version=$(get_latest_pypi_version "$package_name")
 
         # Log errors to console

--- a/install/check_external_version.sh
+++ b/install/check_external_version.sh
@@ -7,7 +7,7 @@ source $mypath/versions.conf
 
 # Function to display usage
 usage() {
-    echo "Usage: $0 -i <input_file> -o <output_file> [-v <vscode_input_file>]"
+    echo "Usage: $0 -i <input_file> -v <vscode_input_file> -o <output_file>"
     echo "  -i, --input        Path to the Python requirements file (e.g., python_requirements.txt)"
     echo "  -v, --vscode-input Path to the VS Code extensions CSV file (e.g., vscode_requirements.csv, optional)"
     echo "  -o, --output       Path to the output CSV file (e.g., package_updates.csv)"
@@ -85,7 +85,7 @@ check_vscodium_version() {
         fi
     fi
 
-    # Write to CSV with right-aligned fields
+    # Write to CSV
     printf "%-5s,%-30s,%15s,%15s,%s\n" "github" "$package_name" "$VERSION_VSCODIUM" "$new_version" "$link" >> "$output_file"
 }
 
@@ -149,14 +149,14 @@ while IFS= read -r line || [[ -n "$line" ]]; do
         elif [[ "$new_version" == "Error fetching version" ]]; then
             echo "Error: Failed to fetch version for package '$package_name' from PyPI."
         elif [[ "$new_version" =~ ^[0-9][0-9a-zA-Z.]*$ ]]; then
-            # Basic validation: ensure new_version starts with a digit
+            # Ensure new_version starts with a digit
             :
         else
             echo "Error: Invalid version format for package '$package_name' (current: $current_version)."
             new_version="Invalid version format"
         fi
 
-        # Write to CSV with right-aligned fields
+        # Write to CSV
         printf "%-5s,%-30s,%15s,%15s,%s\n" "pypi" "$package_name" "$current_version" "$new_version" "https://pypi.org/project/$package_name/" >> "$output_file"
     fi
 done < "$input_file"


### PR DESCRIPTION
Hi a @ngoan1608,
This PR addresses issue [482](https://github.com/test-fullautomation/RobotFramework_AIO/issues/482).
The tool uses the input files python_requirement.txt/python_requirement_lx.txt to create the CSV file as below:

_source,package_name                  ,current_version,    new_version,link_to_new_version
github,vscodium                           ,   1.90.2.24171,    1.100.33714,https://github.com/VSCodium/vscodium/releases
pypi  ,robotframework                  ,          7.3.0,            7.3,https://pypi.org/project/robotframework/
pypi  ,bcrypt                                  ,          4.2.1,          4.3.0,https://pypi.org/project/bcrypt/
pypi  ,cchardet                              ,        2.2.0a2,          2.1.7,https://pypi.org/project/cchardet/_

The CSV file will be saved in the actifact: _linux-aiotestlogfiles-extended\RobotFramework_AIO\package_version_report.csv_
Thank you,
Tri