### PR TITLE
update pypandoc_binary to latest version

### DIFF
--- a/install/python_requirements.txt
+++ b/install/python_requirements.txt
@@ -144,7 +144,7 @@ bokeh==3.7.3
 robotframework-robocop==6.3.0
 pylint==3.3.7
 #pandoc
-pypandoc_binary==1.13
+pypandoc_binary==1.15
 mobly==1.13
 pytest_mock==3.14.1
 odxtools==10.2.1

--- a/install/python_requirements_lx.txt
+++ b/install/python_requirements_lx.txt
@@ -149,7 +149,7 @@ robotframework-robocop==6.3.0
 pylint==3.3.7
 Sphinx==8.2.3
 pandoc==2.4
-pypandoc_binary==1.13
+pypandoc_binary==1.15
 mobly==1.13
 pytest_mock==3.14.1
 odxtools==10.2.1


### PR DESCRIPTION
Hi Thomas,
Hi Holger,

This PR update `pypandoc_binary` to latest version `1.15` which includes pandoc version `3.6.1`.
This will generate the sequence `\pandocbounded`.

Thank you,
Ngoan