### PR TITLE
disable vscode-welcome extension

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -207,7 +207,7 @@ function packaging_vscode() {
 
 	# Find the .vsix file and copy it
 	vsix_file=$(find "$mypath/../../vscode-welcome" -name "*.vsix" -type f | head -n 1)
-	cp -rf "$vsix_file" "$vscodeData/extensions/"
+	# cp -rf "$vsix_file" "$vscodeData/extensions/"
 
 	# Extract the name of the .vsix file
 	vsix_name=$(basename $vsix_file .vsix)


### PR DESCRIPTION
Hi @test-fullautomation, 
This line is temporarily commented out to prevent the vscode-welcome extension from being installed during the pipeline execution.
It can be uncommented once the release is finalized.
This method is a simple solution that avoids potential user modifications to VSCodium which could re-enable the welcome page.
Thank you,
Tri
