### PR TITLE
disable welcome screen

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -247,10 +247,10 @@ function packaging_vscode() {
 	fi
 
    if grep -q '"robotframeworkWelcome.hasSeenWelcome"' "$vscodium_setting_file"; then
-       echo "robotframeworkWelcome.hasSeenWelcome exists, updating to false"
+       echo "robotframeworkWelcome.hasSeenWelcome exists, updating to true"
        sed -i -E 's/"robotframeworkWelcome.hasSeenWelcome":\s*(true|false)/"robotframeworkWelcome.hasSeenWelcome": true/' "$vscodium_setting_file"
    else
-       echo "Append robotframeworkWelcome.hasSeenWelcome with false before closing brace"
+       echo "Append robotframeworkWelcome.hasSeenWelcome with true before closing brace"
        sed -i -E '$ s/}/    "robotframeworkWelcome.hasSeenWelcome": true,\n}/' "$vscodium_setting_file"
    fi
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -246,6 +246,14 @@ function packaging_vscode() {
     },\n}/' "$vscodium_setting_file"
 	fi
 
+   if grep -q '"robotframeworkWelcome.hasSeenWelcome"' "$vscodium_setting_file"; then
+       echo "robotframeworkWelcome.hasSeenWelcome exists, updating to false"
+       sed -i -E 's/"robotframeworkWelcome.hasSeenWelcome":\s*(true|false)/"robotframeworkWelcome.hasSeenWelcome": true/' "$vscodium_setting_file"
+   else
+       echo "Append robotframeworkWelcome.hasSeenWelcome with false before closing brace"
+       sed -i -E '$ s/}/    "robotframeworkWelcome.hasSeenWelcome": true,\n}/' "$vscodium_setting_file"
+   fi
+
 	# Ensure "workbench.startupEditor" is set to "none"
 	if grep -q '"workbench.startupEditor"' "$vscodium_setting_file"; then
 	    echo "workbench.startupEditor exists, updating to none"


### PR DESCRIPTION
Hi @test-fullautomation, 
I have added this script to set the hasSeenWelcome variable to true, ensuring that users will not see the welcome page after installing RobotFramework AIO.
There are two ways to activate the welcome page manually:
- Change the hasSeenWelcome variable in the settings.json file in VSCodium.
- Click the Welcome button located at the bottom-right corner of the status bar.
Thank you,
Tri