### PR TITLE
adds cleanup step to delete .deb packages post-install

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -436,6 +436,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install ./*.deb --fix-missing
+        sudo rm -f ./*.deb
 
     - name: Check external dependencies version
       run: |
@@ -485,6 +486,7 @@ jobs:
         avd-name: my_avd
         target: google_apis
         arch: x86_64
+        profile: pixel_xl
         script: |
           export RobotDevtools="/opt/rfwaio/devtools"
           export ANDROID_HOME="/opt/rfwaio/devtools/Android"


### PR DESCRIPTION
Hi @test-fullautomation 
The PR include a new step that removes the .deb file after the installation process is completed.
This cleanup helps prevent low-storage issues, which previously caused the Android AVD installation to fail due to insufficient available space.
Thank you,
Tri