### PR TITLE
fix Android emulator storage error by freeing up disk space

### DIFF
--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -463,7 +463,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install ./*.deb --fix-missing
-        sudo rm -f ./*.deb
 
     - name: Check external dependencies version
       run: |
@@ -503,7 +502,7 @@ jobs:
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf /opt/ghc
         sudo rm -rf /usr/local/share/boost
-        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        sudo rm -rf "${AGENT_TOOLSDIRECTORY}"
         df -h
 
     - name: Enable KVM group perms
@@ -522,7 +521,6 @@ jobs:
         target: google_apis
         arch: x86_64
         profile: pixel_xl
-
         script: |
           export RobotDevtools="/opt/rfwaio/devtools"
           export ANDROID_HOME="/opt/rfwaio/devtools/Android"

--- a/.github/workflows/build_robotframework_aio.yml
+++ b/.github/workflows/build_robotframework_aio.yml
@@ -498,6 +498,14 @@ jobs:
               exit 1
           fi
 
+    - name: Free up disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/share/boost
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        df -h
+
     - name: Enable KVM group perms
       run: |
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -514,6 +522,7 @@ jobs:
         target: google_apis
         arch: x86_64
         profile: pixel_xl
+
         script: |
           export RobotDevtools="/opt/rfwaio/devtools"
           export ANDROID_HOME="/opt/rfwaio/devtools/Android"


### PR DESCRIPTION
- Add disk cleanup step to remove unused pre-installed software
- Remove .NET SDK, Haskell compiler, Boost C++ libraries, and cached tools
- Resolves "Not enough space to create userdata partition" error