### PR TITLE
Mar3hc/hidden vs codium install update feature

### DIFF
--- a/config/build/dpkg_build/postinst.sh
+++ b/config/build/dpkg_build/postinst.sh
@@ -2,6 +2,9 @@
 # Script to setup enviroment for Robotframework AIO on Linux
 # This should run 1 time when postinst
 
+DO_UPDATE_VSCODIUM_FLAG=false
+[ -f /var/lib/robotframework-aio-do-update-vscodium ] && DO_UPDATE_VSCODIUM_FLAG=true
+
 # This owner change is required when installation with sudo permission
 # File/Folder after copying need to change the owner to actual user instead of root
 function update_owner(){
@@ -137,12 +140,16 @@ function update_vscodium_related(){
       cp -R "$EXT_NEW_DIR" $VSCODE_DATA_DIR
 
       merge_extensions "$EXT_BACKUP_DIR/extensions.json" "$EXT_NEW_DIR/extensions.json" "$VSCODE_DATA_DIR/extensions/extensions.json"
+
+      allow_user_group_permissions "$VSCODE_DATA_DIR/extensions"
    fi
 
    # Restore user's VSCode global storage for reinstalled Vscodium
    if [ -d "$STORAGE_BACKUP_DIR" ]; then
       echo "Restoring user's VSCode global storage..."
       cp -R "$STORAGE_BACKUP_DIR" "$VSCODE_DATA_DIR/user-data/User/"
+
+      allow_user_group_permissions "$VSCODE_DATA_DIR/user-data/User/globalStorage"
    fi
 
    echo "Clean up temporary backup files..."
@@ -306,24 +313,40 @@ if [ -f "${SELECTED_CMPTS_FILE}" ];then
       allow_user_group_permissions /opt/rfwaio/devtools/nodejs/lib
       update_android_related;
    fi
+   if $DO_UPDATE_VSCODIUM_FLAG; then
+      # Dev mode
+      if [[ " ${SELECTED_CMPTS[@]} " =~ " Vscodium (fresh install) " ]] || \
+      [[ " ${SELECTED_CMPTS[@]} " =~ " Vscodium (upgrade/overwrite) " ]]; then
 
-   if [[ " ${SELECTED_CMPTS[@]} " =~ " Vscodium (fresh install) " ]] || \
-   [[ " ${SELECTED_CMPTS[@]} " =~ " Vscodium (upgrade/overwrite) " ]]; then
+         # Update permission of Vscodium-related data
+         ###########################################################################
+         allow_user_group_permissions /opt/rfwaio/robotvscode/data
+         allow_user_group_permissions /opt/rfwaio/robotvscode/RobotTest
+         chmod 4755 /opt/rfwaio/robotvscode/chrome-sandbox
 
-      # Update permission of Vscodium-related data
-      ###########################################################################
-      allow_user_group_permissions /opt/rfwaio/robotvscode/data
-      allow_user_group_permissions /opt/rfwaio/robotvscode/RobotTest
-      chmod 4755 /opt/rfwaio/robotvscode/chrome-sandbox
+         # Extra step only for fresh install
+         if [[ " ${SELECTED_CMPTS[@]} " =~ " Vscodium (fresh install) " ]]; then
+            rm -rf "/tmp/vscode_backup"
+         fi
 
-      # Extra step only for fresh install
-      if [[ " ${SELECTED_CMPTS[@]} " =~ " Vscodium (fresh install) " ]]; then
-         rm -rf "/tmp/vscode_backup"
+         update_vscodium_related;
+      else
+         remove_vscodium_package;
       fi
-
-      update_vscodium_related;
    else
-      remove_vscodium_package;
+      # Dev mode
+      if ! [[ " ${SELECTED_CMPTS[@]} " =~ " Vscodium " ]]; then
+         remove_vscodium_package;
+      else
+         #
+         # Update permission of Vscodium-related data
+         #
+         #############################################################################
+         allow_user_group_permissions /opt/rfwaio/robotvscode/data
+         allow_user_group_permissions /opt/rfwaio/robotvscode/RobotTest
+         chmod 4755 /opt/rfwaio/robotvscode/chrome-sandbox
+         update_vscodium_related;
+      fi
    fi
 
 
@@ -376,3 +399,6 @@ if [ -d "${DLTCONNECTOR_PATH}" ]; then
    echo "For using QConnectionDLTLibrary, please install DTLConnector by below commands:"
    echo "sudo dpkg -i ${DLTCONNECTOR_PATH}${DLTCONNECTOR_NAME}"
 fi
+
+FLAG_FILE="/var/lib/robotframework-aio-do-update-vscodium"
+rm -f "$FLAG_FILE" || true

--- a/config/build/dpkg_build/preinst.sh
+++ b/config/build/dpkg_build/preinst.sh
@@ -1,44 +1,76 @@
 #!/bin/bash
 
-# Define the options with corresponding characters
-EXTRA_CMPTS=(
+DO_UPDATE_VSCODIUM_FLAG=false
+[ -f /var/lib/robotframework-aio-do-update-vscodium ] && DO_UPDATE_VSCODIUM_FLAG=true
+
+if $DO_UPDATE_VSCODIUM_FLAG; then
+   # Dev mode
+   # Define the options with corresponding characters
+   EXTRA_CMPTS=(
+      "    N : No extra package - only the core framework and libraries"
+      "    A : Android package (includes Node.js, Appium server, Appium Inspector, Android SDK tools)" 
+      "    V : Vscodium package"
+      "        1 : Fresh Install of VSCodium"
+      "            - Performs a clean setup with default settings."
+      "            - No previous extensions or user configurations are retained."
+      "        2 : Upgrade Existing VSCodium"
+      "            - Updates the current installation to the latest version."
+      "            - Preserves all existing extensions and user settings."
+      "Enter : All packages (default choice after 30s, includes Android + Vscodium Upgrade [V2])"
+      )
+   DEFAULT_OPT="AV2"
+else
+   # End-user mode
+   EXTRA_CMPTS=(
    "    N : No extra package - only the core framework and libraries"
    "    A : Android package (includes Node.js, Appium server, Appium Inspector, Android SDK tools)" 
    "    V : Vscodium package"
-   "        1 : Fresh Install of VSCodium"
-   "            - Performs a clean setup with default settings."
-   "            - No previous extensions or user configurations are retained."
-   "        2 : Upgrade Existing VSCodium"
-   "            - Updates the current installation to the latest version."
-   "            - Preserves all existing extensions and user settings."
-   "Enter : All packages (default choice after 30s, includes Android + Vscodium Upgrade [V2])"
+   "Enter : All packages (default choice after 30s)"
    )
-DEFAULT_OPT="AV2"
+   DEFAULT_OPT="AV"
+fi
 
 # Display the menu and read user input with timeout
 echo "Select one or more extra components:"
 for option in "${EXTRA_CMPTS[@]}"; do
    echo "$option"
 done
-read -rt 30 -p "Enter your choices (e.g., AV for both Android and VSCodium packages): " choices
+if $DO_UPDATE_VSCODIUM_FLAG; then
+   read -rt 30 -p "Enter your choices (e.g., AV2 for both Android and Vscodium (upgrade/overwrite) packages): " choices
+else
+   read -rt 30 -p "Enter your choices (e.g., AV for both Android and VSCodium packages): " choices
+fi
+   
 
 # Set default value if input is empty
 if [ -z "$choices" ]; then
    choices=$DEFAULT_OPT
 fi
 
-# mkdir /opt/ngoan-dev
-# Process user input
 SELECTED_CMPTS=()
-if [[ "$choices" =~ [Nn] ]]; then
-   SELECTED_CMPTS=() # No extras overrides everything
-elif [[ "$choices" =~ [Aa] ]]; then
-   SELECTED_CMPTS+=("Android")
-fi
-if [[ "$choices" =~ V1|v1 ]]; then
-   SELECTED_CMPTS+=("Vscodium (fresh install)")
-elif [[ "$choices" =~ V2|v2|V|v ]]; then
-   SELECTED_CMPTS+=("Vscodium (upgrade/overwrite)")
+if $DO_UPDATE_VSCODIUM_FLAG; then
+   # Dev mode
+   # mkdir /opt/ngoan-dev
+   # Process user input
+   if [[ "$choices" =~ [Nn] ]]; then
+      SELECTED_CMPTS=() # No extras overrides everything
+   elif [[ "$choices" =~ [Aa] ]]; then
+      SELECTED_CMPTS+=("Android")
+   fi
+   if [[ "$choices" =~ V1|v1 ]]; then
+      SELECTED_CMPTS+=("Vscodium (fresh install)")
+   elif [[ "$choices" =~ V2|v2|V|v ]]; then
+      SELECTED_CMPTS+=("Vscodium (upgrade/overwrite)")
+   fi
+else
+   if [[ "$choices" =~ [Nn] ]]; then
+      SELECTED_CMPTS=() # No extras overrides everything
+   elif [[ "$choices" =~ [Aa] ]]; then
+      SELECTED_CMPTS+=("Android")
+   fi
+   if [[ "$choices" =~ V|v ]]; then
+      SELECTED_CMPTS+=("Vscodium")
+   fi
 fi
 
 # Print selected options

--- a/config/build/dpkg_build/prerm.sh
+++ b/config/build/dpkg_build/prerm.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+###############################################################################
+# Dev-only flag
+# Enable by running:
+#   echo 1 | sudo tee /var/lib/robotframework-aio-do-update-vscodium
+#   sudo apt-get install -y ./*.deb --fix-missing --reinstall --allow-downgrades
+###############################################################################
+
+DO_UPDATE_VSCODIUM_FLAG=false
+[ -f /var/lib/robotframework-aio-do-update-vscodium ] && DO_UPDATE_VSCODIUM_FLAG=true
+
 # Backup VSCode extensions/global storage
 backup_vscode_extensions() {
    echo "Backing up VSCode user data..."
@@ -45,7 +55,10 @@ remove_application_files() {
 case "$1" in
    upgrade)
       echo "Upgrading RobotFramework AIO..."
-      backup_vscode_extensions
+      if $DO_UPDATE_VSCODIUM_FLAG; then
+
+         backup_vscode_extensions
+      fi
       remove_application_files
       ;;
 

--- a/scripts/RobotFrameworkSetup.iss
+++ b/scripts/RobotFrameworkSetup.iss
@@ -266,6 +266,29 @@ var
   ScriptPath: string;
   ReinstallCheckbox: TNewCheckBox;
   VsCodiumPage: TWizardPage;
+  DoVSCodiumUpdate: Boolean;
+
+//
+// Hidden Vscodium update feature
+//////////////////////////////////////////////////////////////
+function InitializeSetup(): Boolean;
+var
+  i: Integer;
+begin
+  DoVSCodiumUpdate := False;
+
+  for i := 1 to ParamCount do
+  begin
+    if CompareText(ParamStr(i), '--do_vscodium_update') = 0 then
+    begin
+      DoVSCodiumUpdate := True;
+      Log('Command line flag detected: VSCodium update ENABLED');
+      Break;
+    end;
+  end;
+
+  Result := True;
+end;
 
 //
 // Maps a given ListPosition to a fix project index
@@ -461,10 +484,13 @@ begin
 		if (IsUpgrade()) then
 		begin
 			sNewInstallation:='False';
-      VSCodiumRemoveDataSelected := ReinstallCheckbox.Checked;
-      // Backup VSCode extensions before uninstalling old version
-      if not VSCodiumRemoveDataSelected then
-        BackupVSCodeData();
+      if DoVSCodiumUpdate then
+      begin
+        VSCodiumRemoveDataSelected := ReinstallCheckbox.Checked;
+        // Backup VSCode extensions before uninstalling old version
+        if not VSCodiumRemoveDataSelected then
+          BackupVSCodeData();
+      end;
 
 			UnInstallOldVersion();
 		end;
@@ -755,43 +781,56 @@ var
   VSCodiumRemoveDataSelected: Boolean;
   NoteLabel: TNewStaticText;
 begin
-  VSCodiumRemoveDataSelected := Assigned(ReinstallCheckbox) and ReinstallCheckbox.Checked;
 
-  if CurPageID = UsrDataDirPage.ID then
+  if DoVSCodiumUpdate then
   begin
-    if DirExists(ExpandConstant('{app}\robotvscode\data\extensions')) and not Assigned(ReinstallCheckbox) then
+    VSCodiumRemoveDataSelected := Assigned(ReinstallCheckbox) and ReinstallCheckbox.Checked;
+    if CurPageID = UsrDataDirPage.ID then
     begin
-      VsCodiumPage := CreateCustomPage(wpSelectComponents, 'VSCodium Installation Options',
-                                      'Choose how you want VSCodium to be installed');
+      if DirExists(ExpandConstant('{app}\robotvscode\data\extensions')) and not Assigned(ReinstallCheckbox) then
+      begin
+        VsCodiumPage := CreateCustomPage(wpSelectComponents, 'VSCodium Installation Options',
+                                        'Choose how you want VSCodium to be installed');
 
-      ReinstallCheckbox := TNewCheckBox.Create(VsCodiumPage);
-      ReinstallCheckbox.Parent := VsCodiumPage.Surface;
-      ReinstallCheckbox.Left := ScaleX(0);
-      ReinstallCheckbox.Top := ScaleY(10);
-      ReinstallCheckbox.Width := VsCodiumPage.SurfaceWidth;
-      ReinstallCheckbox.Height := ScaleY(40);
-      ReinstallCheckbox.Caption :=
-        'Fresh VSCodium installation';
-      ReinstallCheckbox.Checked := False;
+        ReinstallCheckbox := TNewCheckBox.Create(VsCodiumPage);
+        ReinstallCheckbox.Parent := VsCodiumPage.Surface;
+        ReinstallCheckbox.Left := ScaleX(0);
+        ReinstallCheckbox.Top := ScaleY(10);
+        ReinstallCheckbox.Width := VsCodiumPage.SurfaceWidth;
+        ReinstallCheckbox.Height := ScaleY(40);
+        ReinstallCheckbox.Caption :=
+          'Fresh VSCodium installation';
+        ReinstallCheckbox.Checked := False;
 
-      NoteLabel := TNewStaticText.Create(VsCodiumPage);
-      NoteLabel.Parent := VsCodiumPage.Surface;
-      NoteLabel.Left := ScaleX(0);
-      NoteLabel.Top := ReinstallCheckbox.Top + ReinstallCheckbox.Height + ScaleY(4);
-      NoteLabel.Width := VsCodiumPage.SurfaceWidth;
-      NoteLabel.AutoSize := False;
-      NoteLabel.Height := ScaleY(28);
-      NoteLabel.Caption:=
-        'Attention: Reinstalls and removes all extensions and user data';
+        NoteLabel := TNewStaticText.Create(VsCodiumPage);
+        NoteLabel.Parent := VsCodiumPage.Surface;
+        NoteLabel.Left := ScaleX(0);
+        NoteLabel.Top := ReinstallCheckbox.Top + ReinstallCheckbox.Height + ScaleY(4);
+        NoteLabel.Width := VsCodiumPage.SurfaceWidth;
+        NoteLabel.AutoSize := False;
+        NoteLabel.Height := ScaleY(28);
+        NoteLabel.Caption:=
+          'Attention: Reinstalls and removes all extensions and user data';
+      end;
     end;
-  end;
 
-  if Assigned(InfoAfterPage) and (CurPageID = InfoAfterPage.ID) then
+    if Assigned(InfoAfterPage) and (CurPageID = InfoAfterPage.ID) then
+    begin
+      if IsComponentSelected('VsCodium') and (VSCodiumRemoveDataSelected or not Assigned(ReinstallCheckbox)) then
+        InfoAfterPage.Surface.Show
+      else
+        WizardForm.NextButton.OnClick(nil); // skip page
+    end;
+  end
+  else
   begin
-    if IsComponentSelected('VsCodium') and (VSCodiumRemoveDataSelected or not Assigned(ReinstallCheckbox)) then
-      InfoAfterPage.Surface.Show
-    else
-      WizardForm.NextButton.OnClick(nil); // skip page
+    if (CurPageID = InfoAfterPage.ID) then
+    begin
+      if IsComponentSelected('VsCodium') then
+        InfoAfterPage.Surface.Show
+      else
+        WizardForm.NextButton.OnClick(nil); // skip page
+    end;
   end;
 end;
 


### PR DESCRIPTION
Hi all,
This PR hides a new VSCodium installer feature from users, allowing us to internally test, use, and stabilize it until we are confident that it works properly. The feature allows users to upgrade an existing VSCodium installation while preserving their current extensions when installing RobotFramework AIO.
To activate the new installer, please follow the steps below.

**Windows**: 
1. Open Command Prompt (cmd)
2. Run file.exe with the argument --do_vscodium_update 
e.g. `RobotFramework_AIO_setup_extended.exe --do_vscodium_update`

Note:
- If RobotFramework AIO was not previously installed in the user selected installation directory, the page with the “fresh install” checkbox will not appear, and a fresh installation will be performed automatically. After the installation process completes, the page containing the Copilot guide will be shown.

- If RobotFramework AIO is already installed, the page with the “fresh install” checkbox will, but the Copilot guide will not.

**Linux**: 

1. Open a terminal
2. Run the following commands:

`
echo 1 | sudo tee /var/lib/robotframework-aio-do-update-vscodium
`

(This creates a flag file in /var/lib and it will be automatically removed after installation.)

`
sudo apt-get install -y ./*.deb --fix-missing --reinstall --allow-downgrades
`

Note:
- During the installation in the terminal, users will be prompted to choose between a fresh install or an upgrade of VSCodium.

If you encounter any issues during installation or permission-related problems, please provide feedback.

Thank you,
Tri
